### PR TITLE
Feat: serviceaccount auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ The provider requires STACKIT credentials to be provided via a Kubernetes Secret
 | `userData` | No | Default cloud-init user data (can be overridden in ProviderSpec) |
 | `networkId` | No | Default network UUID (can be overridden in ProviderSpec) |
 
+The service account key should be obtained from the STACKIT Portal (Project Settings → Service Accounts → Create Key) and contains JWT credentials and a private key for secure authentication.
+
+### Environment Variables
+
+The provider supports the following environment variables for configuration:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STACKIT_API_ENDPOINT` | (SDK default) | Override STACKIT API endpoint URL (useful for testing) |
+| `STACKIT_NO_AUTH` | `false` | Skip authentication (for testing with mock servers, set to `true`) |
+
+**Note:** `STACKIT_NO_AUTH=true` is only intended for testing environments with mock servers. Do not use in production.
+
 ## Configuration Reference
 
 ### ProviderSpec Fields

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The provider requires STACKIT credentials to be provided via a Kubernetes Secret
 | Field | Required | Description |
 |-------|----------|-------------|
 | `projectId` | Yes | STACKIT project UUID |
-| `stackitToken` | Yes | STACKIT API authentication token |
+| `serviceAccountKey` | Yes | STACKIT service account credentials (JSON format) |
 | `region` | Yes | STACKIT region (e.g., `eu01-1`, `eu01-2`) |
 | `userData` | No | Default cloud-init user data (can be overridden in ProviderSpec) |
 | `networkId` | No | Default network UUID (can be overridden in ProviderSpec) |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Out of tree (controller based) implementation for `STACKIT` as a provider for Ga
 
 A Machine Controller Manager (MCM) external provider implementation for STACKIT cloud infrastructure. This provider enables Gardener to manage virtual machines on STACKIT using the declarative Kubernetes API.
 
-The provider was built following the [MCM provider development guidelines](https://github.com/gardener/machine-controller-manager/blob/master/docs/development/cp_support_new.md) and bootstrapped from the [sample provider template](https://github.com/gardener/machine-controller-manager-provider-sampleprovider).Following are the basic principles kept in mind while developing the external plugin.
+The provider was built following the [MCM provider development guidelines](https://github.com/gardener/machine-controller-manager/blob/master/docs/development/cp_support_new.md) and bootstrapped from the [sample provider template](https://github.com/gardener/machine-controller-manager-provider-sampleprovider).
 
 ## Project Structure
 
@@ -59,7 +59,16 @@ This project uses **Hermit** for reproducible development environments and **jus
 hermit shell-hooks
 ```
 
-**just** is the task runner (defined in `justfile`). It provides a cleaner syntax than Make and better task organization:
+**[just](https://github.com/casey/just)** is the task runner (defined in `justfile`):
+
+```
+just build              # Build the provider binary
+just test               # Run unit tests
+just test-e2e           # Run end-to-end tests
+just dev                # Complete local dev setup (cluster + deployment)
+just start              # Run provider locally for debugging
+just docker-build       # Build container image
+```
 
 ```sh
 # List all available commands
@@ -69,27 +78,14 @@ just --list
 just
 ```
 
-### Quick Start
-
-```sh
-just build              # Build the provider binary
-just test               # Run unit tests
-just test-e2e           # Run end-to-end tests
-just dev                # Complete local dev setup (cluster + deployment)
-just start              # Run provider locally for debugging
-just docker-build       # Build container image
-```
-
-**NOTE:** Run `just --list` for more information on all available commands.
-
 ### Deployment
 
 See the [samples/](./samples/) directory for example manifests including:
-- `secret.yaml` - STACKIT credentials configuration
-- `machine-class.yaml` - MachineClass definition
-- `machine.yaml` - Individual Machine example
-- `machine-deployment.yaml` - MachineDeployment for scaled workloads
-- `deployment.yaml` - Provider controller deployment
+- [`secret.yaml`](./samples/secret.yaml) - STACKIT credentials configuration
+- [`machine-class.yaml`](./samples/machine-class.yaml) - MachineClass definition
+- [`machine.yaml`](./samples/machine.yaml) - Individual Machine example
+- [`machine-deployment.yaml`](./samples/machine-deployment.yaml) - MachineDeployment for scaled workloads
+- [`deployment.yaml`](./kubernetes/deployment.yaml) - Provider controller deployment
 
 Deploy using standard kubectl commands:
 
@@ -128,7 +124,7 @@ The provider supports the following environment variables for configuration:
 | `STACKIT_API_ENDPOINT` | (SDK default) | Override STACKIT API endpoint URL (useful for testing) |
 | `STACKIT_NO_AUTH` | `false` | Skip authentication (for testing with mock servers, set to `true`) |
 
-**Note:** `STACKIT_NO_AUTH=true` is only intended for testing environments with mock servers. Do not use in production.
+**Note:** `STACKIT_NO_AUTH=true` is only intended for testing environments with mock servers. It skips the authenticaiton step and communicates with the STACKIT API without authenticating itself. Do not use in production.
 
 ## Configuration Reference
 
@@ -150,19 +146,6 @@ The provider supports the following environment variables for configuration:
 | `serviceAccountMails` | []string | No | Service account email addresses (max 1) |
 | `agent` | AgentSpec | No | STACKIT agent configuration |
 | `metadata` | map[string]interface{} | No | Custom metadata key-value pairs |
-
-## Contributing
-
-Contributions are welcome! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
-
-### Development Workflow
-
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/my-feature`
-3. Make changes and add tests
-4. Run verification: `just test && just golang::lint`
-5. Commit with meaningful messages
-6. Push and create a Pull Request
 
 ### Local Testing
 

--- a/pkg/provider/apis/validation/validation.go
+++ b/pkg/provider/apis/validation/validation.go
@@ -284,3 +284,9 @@ func isValidMachineType(s string) bool {
 func isValidRegion(s string) bool {
 	return regionRegex.MatchString(s)
 }
+
+// isValidJSON checks if a string is valid JSON
+func isValidJSON(s string) bool {
+	var js json.RawMessage
+	return json.Unmarshal([]byte(s), &js) == nil
+}

--- a/pkg/provider/apis/validation/validation.go
+++ b/pkg/provider/apis/validation/validation.go
@@ -53,32 +53,32 @@ func ValidateProviderSpecNSecret(spec *api.ProviderSpec, secrets *corev1.Secret)
 
 	projectID, ok := secrets.Data["projectId"]
 	if !ok {
-		errors = append(errors, fmt.Errorf("secret must contain 'projectId' field"))
+		errors = append(errors, fmt.Errorf("secret field 'projectId' is required"))
 	} else if len(projectID) == 0 {
-		errors = append(errors, fmt.Errorf("secret 'projectId' cannot be empty"))
+		errors = append(errors, fmt.Errorf("secret field 'projectId' cannot be empty"))
 	} else if !isValidUUID(string(projectID)) {
-		errors = append(errors, fmt.Errorf("secret 'projectId' must be a valid UUID"))
+		errors = append(errors, fmt.Errorf("secret field 'projectId' must be a valid UUID"))
 	}
 
 	// Validate serviceAccountKey (required for authentication)
 	// ServiceAccount Key Flow: JSON string containing service account credentials and private key
 	serviceAccountKey, ok := secrets.Data["serviceAccountKey"]
 	if !ok {
-		errors = append(errors, fmt.Errorf("secret must contain 'serviceAccountKey' field"))
+		errors = append(errors, fmt.Errorf("secret field 'serviceAccountKey' is required"))
 	} else if len(serviceAccountKey) == 0 {
-		errors = append(errors, fmt.Errorf("secret 'serviceAccountKey' cannot be empty"))
+		errors = append(errors, fmt.Errorf("secret field 'serviceAccountKey' cannot be empty"))
 	} else if !isValidJSON(string(serviceAccountKey)) {
-		errors = append(errors, fmt.Errorf("secret 'serviceAccountKey' must be valid JSON (service account credentials)"))
+		errors = append(errors, fmt.Errorf("secret field 'serviceAccountKey' must be valid JSON (service account credentials)"))
 	}
 
 	// Validate region (required for SDK)
 	region, ok := secrets.Data["region"]
 	if !ok {
-		errors = append(errors, fmt.Errorf("secret must contain 'region' field"))
+		errors = append(errors, fmt.Errorf("secret field 'region' is required"))
 	} else if len(region) == 0 {
-		errors = append(errors, fmt.Errorf("secret 'region' cannot be empty"))
+		errors = append(errors, fmt.Errorf("secret field 'region' cannot be empty"))
 	} else if !isValidRegion(string(region)) {
-		errors = append(errors, fmt.Errorf("secret 'region' has invalid format (expected format: eu01-1, eu01-2, etc.)"))
+		errors = append(errors, fmt.Errorf("secret field 'region' has invalid format (expected format: eu01-1, eu01-2, etc.)"))
 	}
 
 	// Validate ProviderSpec

--- a/pkg/provider/apis/validation/validation.go
+++ b/pkg/provider/apis/validation/validation.go
@@ -6,6 +6,7 @@
 package validation
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 
@@ -59,12 +60,15 @@ func ValidateProviderSpecNSecret(spec *api.ProviderSpec, secrets *corev1.Secret)
 		errors = append(errors, fmt.Errorf("secret 'projectId' must be a valid UUID"))
 	}
 
-	// Validate stackitToken (required for authentication)
-	stackitToken, ok := secrets.Data["stackitToken"]
+	// Validate serviceAccountKey (required for authentication)
+	// ServiceAccount Key Flow: JSON string containing service account credentials and private key
+	serviceAccountKey, ok := secrets.Data["serviceAccountKey"]
 	if !ok {
-		errors = append(errors, fmt.Errorf("secret must contain 'stackitToken' field"))
-	} else if len(stackitToken) == 0 {
-		errors = append(errors, fmt.Errorf("secret 'stackitToken' cannot be empty"))
+		errors = append(errors, fmt.Errorf("secret must contain 'serviceAccountKey' field"))
+	} else if len(serviceAccountKey) == 0 {
+		errors = append(errors, fmt.Errorf("secret 'serviceAccountKey' cannot be empty"))
+	} else if !isValidJSON(string(serviceAccountKey)) {
+		errors = append(errors, fmt.Errorf("secret 'serviceAccountKey' must be valid JSON (service account credentials)"))
 	}
 
 	// Validate region (required for SDK)

--- a/pkg/provider/apis/validation/validation_core_labels_test.go
+++ b/pkg/provider/apis/validation/validation_core_labels_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token"),
-				"region":       []byte("eu01-1"),
+				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":            []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/apis/validation/validation_fields_test.go
+++ b/pkg/provider/apis/validation/validation_fields_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token"),
-				"region":       []byte("eu01-1"),
+				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":            []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/apis/validation/validation_networking_test.go
+++ b/pkg/provider/apis/validation/validation_networking_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token"),
-				"region":       []byte("eu01-1"),
+				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":            []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/apis/validation/validation_secgroup_test.go
+++ b/pkg/provider/apis/validation/validation_secgroup_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token"),
-				"region":       []byte("eu01-1"),
+				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":            []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/apis/validation/validation_secret_test.go
+++ b/pkg/provider/apis/validation/validation_secret_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token"),
-				"region":       []byte("eu01-1"),
+				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":            []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/apis/validation/validation_volumes_test.go
+++ b/pkg/provider/apis/validation/validation_volumes_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token"),
-				"region":       []byte("eu01-1"),
+				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":            []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/core.go
+++ b/pkg/provider/core.go
@@ -50,7 +50,7 @@ func (p *Provider) CreateMachine(ctx context.Context, req *driver.CreateMachineR
 
 	// Extract credentials from Secret
 	projectID := string(req.Secret.Data["projectId"])
-	token := string(req.Secret.Data["stackitToken"])
+	serviceAccountKey := string(req.Secret.Data["serviceAccountKey"])
 	region := string(req.Secret.Data["region"])
 
 	// Build labels: merge ProviderSpec labels with MCM-specific labels
@@ -164,7 +164,7 @@ func (p *Provider) CreateMachine(ctx context.Context, req *driver.CreateMachineR
 	}
 
 	// Call STACKIT API to create server
-	server, err := p.client.CreateServer(ctx, token, projectID, region, createReq)
+	server, err := p.client.CreateServer(ctx, serviceAccountKey, projectID, region, createReq)
 	if err != nil {
 		klog.Errorf("Failed to create server for machine %q: %v", req.Machine.Name, err)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to create server: %v", err))
@@ -203,7 +203,7 @@ func (p *Provider) DeleteMachine(ctx context.Context, req *driver.DeleteMachineR
 	}
 
 	// Extract token from Secret for authentication
-	token := string(req.Secret.Data["stackitToken"])
+	serviceAccountKey := string(req.Secret.Data["serviceAccountKey"])
 
 	// Extract region from Secret
 	region := string(req.Secret.Data["region"])
@@ -215,7 +215,7 @@ func (p *Provider) DeleteMachine(ctx context.Context, req *driver.DeleteMachineR
 	}
 
 	// Call STACKIT API to delete server
-	err = p.client.DeleteServer(ctx, token, projectID, region, serverID)
+	err = p.client.DeleteServer(ctx, serviceAccountKey, projectID, region, serverID)
 	if err != nil {
 		// Check if server was not found (404) - this is OK for idempotency
 		if errors.Is(err, ErrServerNotFound) {
@@ -259,7 +259,7 @@ func (p *Provider) GetMachineStatus(ctx context.Context, req *driver.GetMachineS
 	}
 
 	// Extract token from Secret for authentication
-	token := string(req.Secret.Data["stackitToken"])
+	serviceAccountKey := string(req.Secret.Data["serviceAccountKey"])
 
 	// Extract region from Secret
 	region := string(req.Secret.Data["region"])
@@ -272,7 +272,7 @@ func (p *Provider) GetMachineStatus(ctx context.Context, req *driver.GetMachineS
 	}
 
 	// Call STACKIT API to get server status
-	server, err := p.client.GetServer(ctx, token, projectID, region, serverID)
+	server, err := p.client.GetServer(ctx, serviceAccountKey, projectID, region, serverID)
 	if err != nil {
 		// Check if server was not found (404)
 		if errors.Is(err, ErrServerNotFound) {
@@ -310,11 +310,11 @@ func (p *Provider) ListMachines(ctx context.Context, req *driver.ListMachinesReq
 
 	// Extract credentials from Secret
 	projectID := string(req.Secret.Data["projectId"])
-	token := string(req.Secret.Data["stackitToken"])
+	serviceAccountKey := string(req.Secret.Data["serviceAccountKey"])
 	region := string(req.Secret.Data["region"])
 
 	// Call STACKIT API to list all servers
-	servers, err := p.client.ListServers(ctx, token, projectID, region)
+	servers, err := p.client.ListServers(ctx, serviceAccountKey, projectID, region)
 	if err != nil {
 		klog.Errorf("Failed to list servers for MachineClass %q: %v", req.MachineClass.Name, err)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to list servers: %v", err))

--- a/pkg/provider/core_create_machine_basic_test.go
+++ b/pkg/provider/core_create_machine_basic_test.go
@@ -42,7 +42,7 @@ var _ = Describe("CreateMachine", func() {
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token-123"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
 				"region":       []byte("eu01-1"),
 				"networkId":    []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},

--- a/pkg/provider/core_create_machine_config_test.go
+++ b/pkg/provider/core_create_machine_config_test.go
@@ -39,7 +39,7 @@ var _ = Describe("CreateMachine", func() {
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token-123"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
 				"region":       []byte("eu01-1"),
 				"networkId":    []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},

--- a/pkg/provider/core_create_machine_networking_test.go
+++ b/pkg/provider/core_create_machine_networking_test.go
@@ -39,7 +39,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token-123"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
 				"region":       []byte("eu01-1"),
 			},
 		}

--- a/pkg/provider/core_create_machine_storage_test.go
+++ b/pkg/provider/core_create_machine_storage_test.go
@@ -39,7 +39,7 @@ var _ = Describe("CreateMachine", func() {
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token-123"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
 				"region":       []byte("eu01-1"),
 				"networkId":    []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},

--- a/pkg/provider/core_create_machine_userdata_test.go
+++ b/pkg/provider/core_create_machine_userdata_test.go
@@ -40,7 +40,7 @@ var _ = Describe("CreateMachine", func() {
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token-123"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
 				"region":       []byte("eu01-1"),
 				"networkId":    []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},

--- a/pkg/provider/core_delete_machine_test.go
+++ b/pkg/provider/core_delete_machine_test.go
@@ -42,7 +42,7 @@ var _ = Describe("DeleteMachine", func() {
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token-123"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
 				"region":       []byte("eu01-1"),
 				"networkId":    []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},

--- a/pkg/provider/core_get_machine_status_test.go
+++ b/pkg/provider/core_get_machine_status_test.go
@@ -42,7 +42,7 @@ var _ = Describe("GetMachineStatus", func() {
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token-123"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
 				"region":       []byte("eu01-1"),
 				"networkId":    []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},

--- a/pkg/provider/core_list_machines_test.go
+++ b/pkg/provider/core_list_machines_test.go
@@ -41,7 +41,7 @@ var _ = Describe("ListMachines", func() {
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-				"stackitToken": []byte("test-token-123"),
+				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
 			},
 		}
 

--- a/pkg/provider/sdk_client.go
+++ b/pkg/provider/sdk_client.go
@@ -33,12 +33,24 @@ var (
 
 // createIAASClient creates a new STACKIT SDK IAAS API client for a request
 // This allows different MachineClasses to use different credentials
-func (c *sdkStackitClient) createIAASClient(token string) (*iaas.APIClient, error) {
+//
+// Authentication: Uses ServiceAccount Key Flow (recommended by STACKIT)
+// - Automatically generates JWT tokens from service account credentials
+// - Handles token refresh before expiration
+// - More secure than static tokens (short-lived, rotating)
+func (c *sdkStackitClient) createIAASClient(serviceAccountKey string) (*iaas.APIClient, error) {
 	// Configure SDK with custom base URL if provided (for testing with mock server)
 	baseURL := os.Getenv("STACKIT_API_ENDPOINT")
 
 	var opts []config.ConfigurationOption
-	opts = append(opts, config.WithToken(token))
+
+	// Use ServiceAccount Key Flow (production-recommended authentication)
+	// The SDK will:
+	// 1. Parse the service account key JSON
+	// 2. Use the private key to sign JWT tokens
+	// 3. Automatically fetch access tokens from STACKIT token API
+	// 4. Refresh tokens before expiration (with 5s leeway)
+	opts = append(opts, config.WithServiceAccountKey(serviceAccountKey))
 
 	if baseURL != "" {
 		opts = append(opts, config.WithEndpoint(baseURL))
@@ -75,9 +87,9 @@ func extractRegion(secretData map[string][]byte) (string, error) {
 }
 
 // CreateServer creates a new server via STACKIT SDK
-func (c *sdkStackitClient) CreateServer(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+func (c *sdkStackitClient) CreateServer(ctx context.Context, serviceAccountKey, projectID, region string, req *CreateServerRequest) (*Server, error) {
 	// Create SDK client for this request
-	iaasClient, err := c.createIAASClient(token)
+	iaasClient, err := c.createIAASClient(serviceAccountKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SDK client: %w", err)
 	}
@@ -215,9 +227,9 @@ func (c *sdkStackitClient) CreateServer(ctx context.Context, token, projectID, r
 }
 
 // GetServer retrieves a server by ID via STACKIT SDK
-func (c *sdkStackitClient) GetServer(ctx context.Context, token, projectID, region, serverID string) (*Server, error) {
+func (c *sdkStackitClient) GetServer(ctx context.Context, serviceAccountKey, projectID, region, serverID string) (*Server, error) {
 	// Create SDK client for this request
-	iaasClient, err := c.createIAASClient(token)
+	iaasClient, err := c.createIAASClient(serviceAccountKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SDK client: %w", err)
 	}
@@ -243,9 +255,9 @@ func (c *sdkStackitClient) GetServer(ctx context.Context, token, projectID, regi
 }
 
 // DeleteServer deletes a server by ID via STACKIT SDK
-func (c *sdkStackitClient) DeleteServer(ctx context.Context, token, projectID, region, serverID string) error {
+func (c *sdkStackitClient) DeleteServer(ctx context.Context, serviceAccountKey, projectID, region, serverID string) error {
 	// Create SDK client for this request
-	iaasClient, err := c.createIAASClient(token)
+	iaasClient, err := c.createIAASClient(serviceAccountKey)
 	if err != nil {
 		return fmt.Errorf("failed to create SDK client: %w", err)
 	}
@@ -263,9 +275,9 @@ func (c *sdkStackitClient) DeleteServer(ctx context.Context, token, projectID, r
 }
 
 // ListServers lists all servers in a project via STACKIT SDK
-func (c *sdkStackitClient) ListServers(ctx context.Context, token, projectID, region string) ([]*Server, error) {
+func (c *sdkStackitClient) ListServers(ctx context.Context, serviceAccountKey, projectID, region string) ([]*Server, error) {
 	// Create SDK client for this request
-	iaasClient, err := c.createIAASClient(token)
+	iaasClient, err := c.createIAASClient(serviceAccountKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SDK client: %w", err)
 	}

--- a/pkg/provider/sdk_client.go
+++ b/pkg/provider/sdk_client.go
@@ -41,16 +41,22 @@ var (
 func (c *sdkStackitClient) createIAASClient(serviceAccountKey string) (*iaas.APIClient, error) {
 	// Configure SDK with custom base URL if provided (for testing with mock server)
 	baseURL := os.Getenv("STACKIT_API_ENDPOINT")
+	noAuth := os.Getenv("STACKIT_NO_AUTH") == "true"
 
 	var opts []config.ConfigurationOption
 
-	// Use ServiceAccount Key Flow (production-recommended authentication)
-	// The SDK will:
-	// 1. Parse the service account key JSON
-	// 2. Use the private key to sign JWT tokens
-	// 3. Automatically fetch access tokens from STACKIT token API
-	// 4. Refresh tokens before expiration (with 5s leeway)
-	opts = append(opts, config.WithServiceAccountKey(serviceAccountKey))
+	// For testing with mock servers, skip authentication if STACKIT_NO_AUTH=true
+	if noAuth {
+		opts = append(opts, config.WithoutAuthentication())
+	} else {
+		// Use ServiceAccount Key Flow (production-recommended authentication)
+		// The SDK will:
+		// 1. Parse the service account key JSON
+		// 2. Use the private key to sign JWT tokens
+		// 3. Automatically fetch access tokens from STACKIT token API
+		// 4. Refresh tokens before expiration (with 5s leeway)
+		opts = append(opts, config.WithServiceAccountKey(serviceAccountKey))
+	}
 
 	if baseURL != "" {
 		opts = append(opts, config.WithEndpoint(baseURL))

--- a/pkg/provider/sdk_client_test.go
+++ b/pkg/provider/sdk_client_test.go
@@ -7,10 +7,11 @@ package provider
 import (
 	"errors"
 	"fmt"
+	"os"
 
-	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 )
 
 var _ = Describe("SDK Client Helpers", func() {
@@ -41,10 +42,10 @@ var _ = Describe("SDK Client Helpers", func() {
 
 			It("should extract region when other fields are present", func() {
 				secretData := map[string][]byte{
-					"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
+					"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
 					"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-					"region":       []byte("eu01-1"),
-					"userData":     []byte("some-user-data"),
+					"region":            []byte("eu01-1"),
+					"userData":          []byte("some-user-data"),
 				}
 
 				region, err := extractRegion(secretData)
@@ -57,7 +58,7 @@ var _ = Describe("SDK Client Helpers", func() {
 		Context("with missing or invalid region", func() {
 			It("should fail when region field is missing", func() {
 				secretData := map[string][]byte{
-					"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
+					"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
 					"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
 				}
 
@@ -499,6 +500,195 @@ var _ = Describe("SDK Type Conversion Helpers", func() {
 
 				Expect(result).To(BeNil())
 			})
+		})
+	})
+
+	Describe("createIAASClient", func() {
+		var (
+			client *sdkStackitClient
+		)
+
+		BeforeEach(func() {
+			client = newSDKStackitClient()
+		})
+
+		Context("with STACKIT_NO_AUTH enabled", func() {
+			It("should create client successfully without authentication", func() {
+				// Set environment variable to skip authentication
+				originalNoAuth := os.Getenv("STACKIT_NO_AUTH")
+				os.Setenv("STACKIT_NO_AUTH", "true")
+				defer func() {
+					if originalNoAuth == "" {
+						os.Unsetenv("STACKIT_NO_AUTH")
+					} else {
+						os.Setenv("STACKIT_NO_AUTH", originalNoAuth)
+					}
+				}()
+
+				iaasClient, err := client.createIAASClient("")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(iaasClient).NotTo(BeNil())
+			})
+
+			It("should create client with any service account key when no auth is enabled", func() {
+				// When STACKIT_NO_AUTH=true, the serviceAccountKey should be ignored
+				originalNoAuth := os.Getenv("STACKIT_NO_AUTH")
+				os.Setenv("STACKIT_NO_AUTH", "true")
+				defer func() {
+					if originalNoAuth == "" {
+						os.Unsetenv("STACKIT_NO_AUTH")
+					} else {
+						os.Setenv("STACKIT_NO_AUTH", originalNoAuth)
+					}
+				}()
+
+				iaasClient, err := client.createIAASClient("invalid-key")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(iaasClient).NotTo(BeNil())
+			})
+		})
+
+		Context("with custom endpoint", func() {
+			It("should create client with custom endpoint when STACKIT_API_ENDPOINT is set", func() {
+				// Set both environment variables
+				originalEndpoint := os.Getenv("STACKIT_API_ENDPOINT")
+				originalNoAuth := os.Getenv("STACKIT_NO_AUTH")
+				os.Setenv("STACKIT_API_ENDPOINT", "https://test.example.com")
+				os.Setenv("STACKIT_NO_AUTH", "true")
+				defer func() {
+					if originalEndpoint == "" {
+						os.Unsetenv("STACKIT_API_ENDPOINT")
+					} else {
+						os.Setenv("STACKIT_API_ENDPOINT", originalEndpoint)
+					}
+					if originalNoAuth == "" {
+						os.Unsetenv("STACKIT_NO_AUTH")
+					} else {
+						os.Setenv("STACKIT_NO_AUTH", originalNoAuth)
+					}
+				}()
+
+				iaasClient, err := client.createIAASClient("")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(iaasClient).NotTo(BeNil())
+			})
+
+			It("should work with default endpoint when STACKIT_API_ENDPOINT is not set", func() {
+				// Ensure endpoint is not set
+				originalEndpoint := os.Getenv("STACKIT_API_ENDPOINT")
+				originalNoAuth := os.Getenv("STACKIT_NO_AUTH")
+				os.Unsetenv("STACKIT_API_ENDPOINT")
+				os.Setenv("STACKIT_NO_AUTH", "true")
+				defer func() {
+					if originalEndpoint != "" {
+						os.Setenv("STACKIT_API_ENDPOINT", originalEndpoint)
+					}
+					if originalNoAuth == "" {
+						os.Unsetenv("STACKIT_NO_AUTH")
+					} else {
+						os.Setenv("STACKIT_NO_AUTH", originalNoAuth)
+					}
+				}()
+
+				iaasClient, err := client.createIAASClient("")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(iaasClient).NotTo(BeNil())
+			})
+		})
+
+		Context("with service account authentication", func() {
+			It("should fail with invalid JSON service account key", func() {
+				// Ensure authentication is enabled
+				originalNoAuth := os.Getenv("STACKIT_NO_AUTH")
+				os.Unsetenv("STACKIT_NO_AUTH")
+				defer func() {
+					if originalNoAuth != "" {
+						os.Setenv("STACKIT_NO_AUTH", originalNoAuth)
+					}
+				}()
+
+				_, err := client.createIAASClient("not-valid-json")
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to create STACKIT SDK API client"))
+			})
+
+			It("should fail with empty service account key", func() {
+				// Ensure authentication is enabled
+				originalNoAuth := os.Getenv("STACKIT_NO_AUTH")
+				os.Unsetenv("STACKIT_NO_AUTH")
+				defer func() {
+					if originalNoAuth != "" {
+						os.Setenv("STACKIT_NO_AUTH", originalNoAuth)
+					}
+				}()
+
+				_, err := client.createIAASClient("")
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to create STACKIT SDK API client"))
+			})
+
+			It("should fail with valid JSON but missing required fields", func() {
+				// Ensure authentication is enabled
+				originalNoAuth := os.Getenv("STACKIT_NO_AUTH")
+				os.Unsetenv("STACKIT_NO_AUTH")
+				defer func() {
+					if originalNoAuth != "" {
+						os.Setenv("STACKIT_NO_AUTH", originalNoAuth)
+					}
+				}()
+
+				// Valid JSON but not a valid service account key structure
+				_, err := client.createIAASClient(`{"some": "json"}`)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to create STACKIT SDK API client"))
+			})
+		})
+
+		Context("stateless client behavior", func() {
+			It("should create new client instance each time", func() {
+				// Use STACKIT_NO_AUTH to avoid needing valid credentials
+				originalNoAuth := os.Getenv("STACKIT_NO_AUTH")
+				os.Setenv("STACKIT_NO_AUTH", "true")
+				defer func() {
+					if originalNoAuth == "" {
+						os.Unsetenv("STACKIT_NO_AUTH")
+					} else {
+						os.Setenv("STACKIT_NO_AUTH", originalNoAuth)
+					}
+				}()
+
+				client1, err1 := client.createIAASClient("")
+				client2, err2 := client.createIAASClient("")
+
+				Expect(err1).NotTo(HaveOccurred())
+				Expect(err2).NotTo(HaveOccurred())
+				Expect(client1).NotTo(BeNil())
+				Expect(client2).NotTo(BeNil())
+				// Note: We can't easily verify they're different instances without
+				// accessing internal SDK state, but the test documents the intent
+			})
+		})
+	})
+
+	Describe("newSDKStackitClient", func() {
+		It("should create a new SDK client wrapper", func() {
+			client := newSDKStackitClient()
+
+			Expect(client).NotTo(BeNil())
+		})
+
+		It("should create stateless client (no internal state)", func() {
+			client := newSDKStackitClient()
+
+			// The client should be stateless - just a wrapper
+			Expect(client).To(BeAssignableToTypeOf(&sdkStackitClient{}))
 		})
 	})
 

--- a/pkg/provider/sdk_client_test.go
+++ b/pkg/provider/sdk_client_test.go
@@ -42,7 +42,7 @@ var _ = Describe("SDK Client Helpers", func() {
 			It("should extract region when other fields are present", func() {
 				secretData := map[string][]byte{
 					"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-					"stackitToken": []byte("test-token-123"),
+					"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
 					"region":       []byte("eu01-1"),
 					"userData":     []byte("some-user-data"),
 				}
@@ -58,7 +58,7 @@ var _ = Describe("SDK Client Helpers", func() {
 			It("should fail when region field is missing", func() {
 				secretData := map[string][]byte{
 					"projectId":    []byte("11111111-2222-3333-4444-555555555555"),
-					"stackitToken": []byte("test-token-123"),
+					"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
 				}
 
 				_, err := extractRegion(secretData)

--- a/pkg/provider/stackit_client.go
+++ b/pkg/provider/stackit_client.go
@@ -11,17 +11,21 @@ import (
 // StackitClient is an interface for interacting with STACKIT IAAS API
 // This allows us to mock the client in unit tests
 //
+// Authentication: Uses ServiceAccount Key Flow (STACKIT SDK v1.0.0+)
+// - serviceAccountKey: JSON string containing service account credentials and private key
+// - The SDK automatically handles JWT token generation and refresh
+//
 // Note: region parameter is required by STACKIT SDK v1.0.0+
 // It must be extracted from the Secret (e.g., "eu01-1", "eu01-2")
 type StackitClient interface {
 	// CreateServer creates a new server in STACKIT
-	CreateServer(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error)
+	CreateServer(ctx context.Context, serviceAccountKey, projectID, region string, req *CreateServerRequest) (*Server, error)
 	// GetServer retrieves a server by ID from STACKIT
-	GetServer(ctx context.Context, token, projectID, region, serverID string) (*Server, error)
+	GetServer(ctx context.Context, serviceAccountKey, projectID, region, serverID string) (*Server, error)
 	// DeleteServer deletes a server by ID from STACKIT
-	DeleteServer(ctx context.Context, token, projectID, region, serverID string) error
+	DeleteServer(ctx context.Context, serviceAccountKey, projectID, region, serverID string) error
 	// ListServers lists all servers in a project
-	ListServers(ctx context.Context, token, projectID, region string) ([]*Server, error)
+	ListServers(ctx context.Context, serviceAccountKey, projectID, region string) ([]*Server, error)
 }
 
 // CreateServerRequest represents the request to create a server

--- a/samples/secret.yaml
+++ b/samples/secret.yaml
@@ -8,8 +8,17 @@ stringData:
   # STACKIT project ID (UUID format)
   projectId: "12345678-1234-1234-1234-123456789012"
 
-  # STACKIT API authentication token
-  stackitToken: "your-stackit-api-token-here"
+  # STACKIT Service Account Key (JSON format)
+  # Obtain from STACKIT Portal: Project Settings -> Service Accounts -> Create Key
+  serviceAccountKey: |
+    {
+      "credentials": {
+        "iss": "service-account-email@sa.stackit.cloud",
+        "sub": "uuid-of-service-account",
+        "aud": "stackit"
+      },
+      "privateKey": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+    }
 
   # STACKIT region (required by SDK v1.0.0+)
   # Valid regions: eu01-1, eu01-2, etc.

--- a/samples/secret.yaml
+++ b/samples/secret.yaml
@@ -9,7 +9,22 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
 
   # STACKIT Service Account Key (JSON format)
-  # Obtain from STACKIT Portal: Project Settings -> Service Accounts -> Create Key
+  #
+  # How to obtain:
+  # 1. Login to STACKIT Portal (https://portal.stackit.cloud)
+  # 2. Navigate to your project
+  # 3. Go to: Project Settings → Service Accounts
+  # 4. Click "Create Service Account" (or use existing one)
+  # 5. Click "Create Key" on the service account
+  # 6. Download the JSON key file
+  # 7. Copy the entire JSON content here (including credentials and privateKey)
+  #
+  # The JSON contains:
+  # - credentials: JWT claims (iss, sub, aud) for token generation
+  # - privateKey: RSA private key for signing JWT tokens
+  #
+  # Security: Never commit this secret to source control!
+  # Use Kubernetes secrets management or external secret stores.
   serviceAccountKey: |
     {
       "credentials": {

--- a/test/e2e/e2e_affinity_test.go
+++ b/test/e2e/e2e_affinity_test.go
@@ -29,7 +29,7 @@ var _ = Describe("MCM Provider STACKIT", func() {
   type: Opaque
   stringData:
     projectId: "12345678-1234-1234-1234-123456789012"
-    stackitToken: "mock-token-for-e2e-tests"
+    serviceAccountKey: "{}"
     region: "eu01-1"
     networkId: "770e8400-e29b-41d4-a716-446655440000"
     userData: |

--- a/test/e2e/e2e_agent_test.go
+++ b/test/e2e/e2e_agent_test.go
@@ -29,7 +29,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |

--- a/test/e2e/e2e_az_test.go
+++ b/test/e2e/e2e_az_test.go
@@ -29,7 +29,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |

--- a/test/e2e/e2e_keypair_test.go
+++ b/test/e2e/e2e_keypair_test.go
@@ -29,7 +29,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |

--- a/test/e2e/e2e_labels_test.go
+++ b/test/e2e/e2e_labels_test.go
@@ -34,7 +34,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
@@ -214,7 +214,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
@@ -412,7 +412,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |

--- a/test/e2e/e2e_lifecycle_test.go
+++ b/test/e2e/e2e_lifecycle_test.go
@@ -29,7 +29,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
@@ -135,7 +135,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
@@ -231,7 +231,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |

--- a/test/e2e/e2e_metadata_test.go
+++ b/test/e2e/e2e_metadata_test.go
@@ -29,7 +29,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |

--- a/test/e2e/e2e_networking_test.go
+++ b/test/e2e/e2e_networking_test.go
@@ -28,7 +28,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   userData: |
     #cloud-config
@@ -97,7 +97,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   userData: |
     #cloud-config
@@ -168,7 +168,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   userData: |
     #cloud-config

--- a/test/e2e/e2e_service_accounts_test.go
+++ b/test/e2e/e2e_service_accounts_test.go
@@ -29,7 +29,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |

--- a/test/e2e/e2e_userdata_test.go
+++ b/test/e2e/e2e_userdata_test.go
@@ -31,7 +31,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
@@ -106,7 +106,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
@@ -177,7 +177,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |

--- a/test/e2e/e2e_volumes_test.go
+++ b/test/e2e/e2e_volumes_test.go
@@ -31,7 +31,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
@@ -105,7 +105,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
@@ -179,7 +179,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
@@ -255,7 +255,7 @@ metadata:
 type: Opaque
 stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
-  stackitToken: "mock-token-for-e2e-tests"
+  serviceAccountKey: "{}"
   region: "eu01-1"
   networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |


### PR DESCRIPTION
Implementing ServiceAccount auth against STACKIT SDK instead of Token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace token-based auth with `serviceAccountKey` (JSON) across provider, SDK client, validation, docs, samples, and tests; add env flags for endpoint/no-auth.
> 
> - **Provider / SDK**:
>   - Switch all API calls to use `serviceAccountKey` instead of `stackitToken` in `pkg/provider/core.go`, `pkg/provider/sdk_client.go`, and `pkg/provider/stackit_client.go`.
>   - Implement Service Account Key auth via SDK (`config.WithServiceAccountKey`) with optional `STACKIT_NO_AUTH` and `STACKIT_API_ENDPOINT` overrides.
> - **Validation**:
>   - Require `secret` field `serviceAccountKey` (must be valid JSON) and refine error messages in `pkg/provider/apis/validation/validation.go`.
> - **Docs & Samples**:
>   - Update `README.md` with Service Account auth, env vars, and revised `just` usage.
>   - Replace sample secret to use `serviceAccountKey` in `samples/secret.yaml`.
> - **Tests**:
>   - Update unit and e2e tests to use `serviceAccountKey` and new auth flow across `pkg/provider/**_test.go` and `test/e2e/**`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57f8ccf3645a02f43dd097aff5431cd4c665510e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->