### PR TITLE
fix: iaas client only created once

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ kubectl apply -f samples/machine.yaml
 
 This provider uses the official [STACKIT Go SDK](https://github.com/stackitcloud/stackit-sdk-go) for all interactions with the STACKIT IaaS API. The SDK provides type-safe API access, built-in authentication handling, and is officially maintained by STACKIT.
 
-The SDK client is stateless and supports different credentials per MachineClass, allowing multi-tenancy scenarios where different machine pools use different STACKIT projects.
+Each provider instance is bound to a single STACKIT project via the service account credentials provided in the Secret. The SDK client is initialized once on first use and automatically handles token refresh. In Gardener deployments, each shoot cluster gets its own control plane with a dedicated MCM and provider instance.
 
 ### Authentication & Credentials
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ The provider requires STACKIT credentials to be provided via a Kubernetes Secret
 
 The service account key should be obtained from the STACKIT Portal (Project Settings → Service Accounts → Create Key) and contains JWT credentials and a private key for secure authentication.
 
+**Credential Rotation:** The provider captures credentials on first use and reuses the same STACKIT SDK client for all subsequent requests (the SDK automatically handles token refresh). If the Secret is updated with new credentials, the provider pod must be restarted to pick up the changes. This follows the standard Kubernetes pattern for credential rotation.
+
 ### Environment Variables
 
 The provider supports the following environment variables for configuration:

--- a/pkg/provider/core_create_machine_basic_test.go
+++ b/pkg/provider/core_create_machine_basic_test.go
@@ -95,7 +95,7 @@ var _ = Describe("CreateMachine", func() {
 			var capturedReq *CreateServerRequest
 			var capturedProjectID string
 
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedProjectID = projectID
 				capturedReq = req
 				return &Server{
@@ -165,7 +165,7 @@ var _ = Describe("CreateMachine", func() {
 
 	Context("when STACKIT API fails", func() {
 		It("should return Internal error on API failure", func() {
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				return nil, fmt.Errorf("API connection failed")
 			}
 

--- a/pkg/provider/core_create_machine_config_test.go
+++ b/pkg/provider/core_create_machine_config_test.go
@@ -89,7 +89,7 @@ var _ = Describe("CreateMachine", func() {
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -107,7 +107,7 @@ var _ = Describe("CreateMachine", func() {
 
 		It("should not send KeypairName when empty", func() {
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -135,7 +135,7 @@ var _ = Describe("CreateMachine", func() {
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -153,7 +153,7 @@ var _ = Describe("CreateMachine", func() {
 
 		It("should not send AvailabilityZone when empty", func() {
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -181,7 +181,7 @@ var _ = Describe("CreateMachine", func() {
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -199,7 +199,7 @@ var _ = Describe("CreateMachine", func() {
 
 		It("should not send AffinityGroup when empty", func() {
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -227,7 +227,7 @@ var _ = Describe("CreateMachine", func() {
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -247,7 +247,7 @@ var _ = Describe("CreateMachine", func() {
 
 		It("should not send ServiceAccountMails when empty", func() {
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -276,7 +276,7 @@ var _ = Describe("CreateMachine", func() {
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -295,7 +295,7 @@ var _ = Describe("CreateMachine", func() {
 
 		It("should not send Agent when nil", func() {
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -325,7 +325,7 @@ var _ = Describe("CreateMachine", func() {
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -348,7 +348,7 @@ var _ = Describe("CreateMachine", func() {
 
 		It("should not send Metadata when nil", func() {
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",

--- a/pkg/provider/core_create_machine_networking_test.go
+++ b/pkg/provider/core_create_machine_networking_test.go
@@ -80,7 +80,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 			}
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -126,7 +126,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 			}
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -174,7 +174,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 			}
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -215,7 +215,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 			}
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -263,7 +263,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 			}
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",

--- a/pkg/provider/core_create_machine_storage_test.go
+++ b/pkg/provider/core_create_machine_storage_test.go
@@ -98,7 +98,7 @@ var _ = Describe("CreateMachine", func() {
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -132,7 +132,7 @@ var _ = Describe("CreateMachine", func() {
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -162,7 +162,7 @@ var _ = Describe("CreateMachine", func() {
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -196,7 +196,7 @@ var _ = Describe("CreateMachine", func() {
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -216,7 +216,7 @@ var _ = Describe("CreateMachine", func() {
 
 		It("should not send volumes when not specified", func() {
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",

--- a/pkg/provider/core_create_machine_userdata_test.go
+++ b/pkg/provider/core_create_machine_userdata_test.go
@@ -90,7 +90,7 @@ var _ = Describe("CreateMachine", func() {
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -111,7 +111,7 @@ var _ = Describe("CreateMachine", func() {
 			secret.Data["userData"] = []byte("#cloud-config\nruncmd:\n  - echo 'Hello from Secret'")
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -139,7 +139,7 @@ var _ = Describe("CreateMachine", func() {
 			secret.Data["userData"] = []byte("#cloud-config from Secret")
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -158,7 +158,7 @@ var _ = Describe("CreateMachine", func() {
 
 		It("should not send userData when neither ProviderSpec nor Secret have it", func() {
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",
@@ -178,7 +178,7 @@ var _ = Describe("CreateMachine", func() {
 			secret.Data["userData"] = []byte("")
 
 			var capturedReq *CreateServerRequest
-			mockClient.createServerFunc = func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+			mockClient.createServerFunc = func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 				capturedReq = req
 				return &Server{
 					ID:     "test-server-id",

--- a/pkg/provider/core_delete_machine_test.go
+++ b/pkg/provider/core_delete_machine_test.go
@@ -86,7 +86,7 @@ var _ = Describe("DeleteMachine", func() {
 
 	Context("with valid inputs", func() {
 		It("should successfully delete a machine", func() {
-			mockClient.deleteServerFunc = func(ctx context.Context, token, projectID, region, serverID string) error {
+			mockClient.deleteServerFunc = func(ctx context.Context, projectID, region, serverID string) error {
 				return nil
 			}
 
@@ -100,7 +100,7 @@ var _ = Describe("DeleteMachine", func() {
 			var capturedProjectID string
 			var capturedServerID string
 
-			mockClient.deleteServerFunc = func(ctx context.Context, token, projectID, region, serverID string) error {
+			mockClient.deleteServerFunc = func(ctx context.Context, projectID, region, serverID string) error {
 				capturedProjectID = projectID
 				capturedServerID = serverID
 				return nil
@@ -140,7 +140,7 @@ var _ = Describe("DeleteMachine", func() {
 
 	Context("when machine not found", func() {
 		It("should return success if machine does not exist (idempotent)", func() {
-			mockClient.deleteServerFunc = func(ctx context.Context, token, projectID, region, serverID string) error {
+			mockClient.deleteServerFunc = func(ctx context.Context, projectID, region, serverID string) error {
 				return fmt.Errorf("%w: status 404", ErrServerNotFound)
 			}
 
@@ -153,7 +153,7 @@ var _ = Describe("DeleteMachine", func() {
 
 	Context("when STACKIT API fails", func() {
 		It("should return error when API call fails", func() {
-			mockClient.deleteServerFunc = func(ctx context.Context, token, projectID, region, serverID string) error {
+			mockClient.deleteServerFunc = func(ctx context.Context, projectID, region, serverID string) error {
 				return fmt.Errorf("API connection failed")
 			}
 

--- a/pkg/provider/core_get_machine_status_test.go
+++ b/pkg/provider/core_get_machine_status_test.go
@@ -86,7 +86,7 @@ var _ = Describe("GetMachineStatus", func() {
 
 	Context("with valid inputs", func() {
 		It("should successfully get machine status when server exists", func() {
-			mockClient.getServerFunc = func(ctx context.Context, token, projectID, region, serverID string) (*Server, error) {
+			mockClient.getServerFunc = func(ctx context.Context, projectID, region, serverID string) (*Server, error) {
 				return &Server{
 					ID:     serverID,
 					Name:   "test-machine",
@@ -106,7 +106,7 @@ var _ = Describe("GetMachineStatus", func() {
 			var capturedProjectID string
 			var capturedServerID string
 
-			mockClient.getServerFunc = func(ctx context.Context, token, projectID, region, serverID string) (*Server, error) {
+			mockClient.getServerFunc = func(ctx context.Context, projectID, region, serverID string) (*Server, error) {
 				capturedProjectID = projectID
 				capturedServerID = serverID
 				return &Server{
@@ -161,7 +161,7 @@ var _ = Describe("GetMachineStatus", func() {
 
 	Context("when server does not exist", func() {
 		It("should return NotFound when server is not found", func() {
-			mockClient.getServerFunc = func(ctx context.Context, token, projectID, region, serverID string) (*Server, error) {
+			mockClient.getServerFunc = func(ctx context.Context, projectID, region, serverID string) (*Server, error) {
 				return nil, fmt.Errorf("%w: status 404", ErrServerNotFound)
 			}
 
@@ -176,7 +176,7 @@ var _ = Describe("GetMachineStatus", func() {
 
 	Context("when STACKIT API fails", func() {
 		It("should return Internal error on API failure", func() {
-			mockClient.getServerFunc = func(ctx context.Context, token, projectID, region, serverID string) (*Server, error) {
+			mockClient.getServerFunc = func(ctx context.Context, projectID, region, serverID string) (*Server, error) {
 				return nil, fmt.Errorf("API connection failed")
 			}
 

--- a/pkg/provider/core_list_machines_test.go
+++ b/pkg/provider/core_list_machines_test.go
@@ -71,7 +71,7 @@ var _ = Describe("ListMachines", func() {
 
 	Context("with valid inputs", func() {
 		It("should list machines filtered by MachineClass label", func() {
-			mockClient.listServersFunc = func(ctx context.Context, token, projectID, region string) ([]*Server, error) {
+			mockClient.listServersFunc = func(ctx context.Context, projectID, region string) ([]*Server, error) {
 				return []*Server{
 					{
 						ID:   "server-1",
@@ -111,7 +111,7 @@ var _ = Describe("ListMachines", func() {
 		})
 
 		It("should return empty list when no servers match", func() {
-			mockClient.listServersFunc = func(ctx context.Context, token, projectID, region string) ([]*Server, error) {
+			mockClient.listServersFunc = func(ctx context.Context, projectID, region string) ([]*Server, error) {
 				return []*Server{
 					{
 						ID:   "server-1",
@@ -131,7 +131,7 @@ var _ = Describe("ListMachines", func() {
 		})
 
 		It("should return empty list when no servers exist", func() {
-			mockClient.listServersFunc = func(ctx context.Context, token, projectID, region string) ([]*Server, error) {
+			mockClient.listServersFunc = func(ctx context.Context, projectID, region string) ([]*Server, error) {
 				return []*Server{}, nil
 			}
 
@@ -143,7 +143,7 @@ var _ = Describe("ListMachines", func() {
 		})
 
 		It("should handle servers without labels gracefully", func() {
-			mockClient.listServersFunc = func(ctx context.Context, token, projectID, region string) ([]*Server, error) {
+			mockClient.listServersFunc = func(ctx context.Context, projectID, region string) ([]*Server, error) {
 				return []*Server{
 					{
 						ID:     "server-1",
@@ -172,7 +172,7 @@ var _ = Describe("ListMachines", func() {
 
 	Context("when STACKIT API fails", func() {
 		It("should return Internal error on API failure", func() {
-			mockClient.listServersFunc = func(ctx context.Context, token, projectID, region string) ([]*Server, error) {
+			mockClient.listServersFunc = func(ctx context.Context, projectID, region string) ([]*Server, error) {
 				return nil, fmt.Errorf("API connection failed")
 			}
 

--- a/pkg/provider/core_mocks_test.go
+++ b/pkg/provider/core_mocks_test.go
@@ -11,16 +11,17 @@ import (
 )
 
 // mockStackitClient is a mock implementation of StackitClient for testing
+// Note: Single-tenant design - each client is bound to one set of credentials
 type mockStackitClient struct {
-	createServerFunc func(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error)
-	getServerFunc    func(ctx context.Context, token, projectID, region, serverID string) (*Server, error)
-	deleteServerFunc func(ctx context.Context, token, projectID, region, serverID string) error
-	listServersFunc  func(ctx context.Context, token, projectID, region string) ([]*Server, error)
+	createServerFunc func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error)
+	getServerFunc    func(ctx context.Context, projectID, region, serverID string) (*Server, error)
+	deleteServerFunc func(ctx context.Context, projectID, region, serverID string) error
+	listServersFunc  func(ctx context.Context, projectID, region string) ([]*Server, error)
 }
 
-func (m *mockStackitClient) CreateServer(ctx context.Context, token, projectID, region string, req *CreateServerRequest) (*Server, error) {
+func (m *mockStackitClient) CreateServer(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 	if m.createServerFunc != nil {
-		return m.createServerFunc(ctx, token, projectID, region, req)
+		return m.createServerFunc(ctx, projectID, region, req)
 	}
 	return &Server{
 		ID:     "550e8400-e29b-41d4-a716-446655440000",
@@ -29,9 +30,9 @@ func (m *mockStackitClient) CreateServer(ctx context.Context, token, projectID, 
 	}, nil
 }
 
-func (m *mockStackitClient) GetServer(ctx context.Context, token, projectID, region, serverID string) (*Server, error) {
+func (m *mockStackitClient) GetServer(ctx context.Context, projectID, region, serverID string) (*Server, error) {
 	if m.getServerFunc != nil {
-		return m.getServerFunc(ctx, token, projectID, region, serverID)
+		return m.getServerFunc(ctx, projectID, region, serverID)
 	}
 	return &Server{
 		ID:     serverID,
@@ -40,16 +41,16 @@ func (m *mockStackitClient) GetServer(ctx context.Context, token, projectID, reg
 	}, nil
 }
 
-func (m *mockStackitClient) DeleteServer(ctx context.Context, token, projectID, region, serverID string) error {
+func (m *mockStackitClient) DeleteServer(ctx context.Context, projectID, region, serverID string) error {
 	if m.deleteServerFunc != nil {
-		return m.deleteServerFunc(ctx, token, projectID, region, serverID)
+		return m.deleteServerFunc(ctx, projectID, region, serverID)
 	}
 	return nil
 }
 
-func (m *mockStackitClient) ListServers(ctx context.Context, token, projectID, region string) ([]*Server, error) {
+func (m *mockStackitClient) ListServers(ctx context.Context, projectID, region string) ([]*Server, error) {
 	if m.listServersFunc != nil {
-		return m.listServersFunc(ctx, token, projectID, region)
+		return m.listServersFunc(ctx, projectID, region)
 	}
 	return []*Server{}, nil
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aoepeople/machine-controller-manager-provider-stackit/pkg/spi"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
+	"k8s.io/klog"
 )
 
 // Provider is the struct that implements the driver interface
@@ -20,11 +21,13 @@ import (
 // - Each provider instance is deployed per Gardener shoot (cluster)
 // - The STACKIT IaaS client is initialized lazily on first request using credentials from the Secret
 // - All subsequent requests reuse the same client (SDK handles token refresh automatically)
+// - Credential rotation requires pod restart (standard Kubernetes pattern)
 type Provider struct {
-	SPI        spi.SessionProviderInterface
-	client     StackitClient // STACKIT API client (can be mocked for testing)
-	clientOnce sync.Once     // Ensures client is initialized exactly once
-	clientErr  error         // Stores initialization error if any
+	SPI                   spi.SessionProviderInterface
+	client                StackitClient // STACKIT API client (can be mocked for testing)
+	clientOnce            sync.Once     // Ensures client is initialized exactly once
+	clientErr             error         // Stores initialization error if any
+	capturedCredentials   string        // Service account key used for initialization (for defensive checks)
 }
 
 // NewProvider returns an empty provider object
@@ -37,7 +40,12 @@ func NewProvider(spi spi.SessionProviderInterface) driver.Driver {
 // ensureClient initializes the STACKIT client on first use (lazy initialization)
 // This is called by all methods that need to interact with STACKIT API
 // Thread-safe via sync.Once
-// If a client is already set (e.g., mock client in tests), initialization is skipped
+//
+// Design: Single-credential lifecycle
+// - The serviceAccountKey parameter is captured and used ONLY on the first call
+// - Subsequent calls reuse the same client regardless of the serviceAccountKey passed
+// - Credential rotation requires pod restart (standard Kubernetes pattern)
+// - If a client is already set (e.g., mock client in tests), initialization is skipped
 func (p *Provider) ensureClient(serviceAccountKey string) error {
 	// If client is already set (e.g., mock client in tests), skip initialization
 	if p.client != nil {
@@ -51,6 +59,14 @@ func (p *Provider) ensureClient(serviceAccountKey string) error {
 			return
 		}
 		p.client = client
+		p.capturedCredentials = serviceAccountKey
 	})
+
+	// Defensive check: warn if credentials changed after initialization
+	// This indicates the Secret was updated, which requires pod restart
+	if p.clientErr == nil && p.capturedCredentials != serviceAccountKey {
+		klog.Warning("Service account credentials changed after client initialization. Credential rotation requires pod restart. Continuing with original credentials.")
+	}
+
 	return p.clientErr
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -6,21 +6,51 @@
 package provider
 
 import (
+	"fmt"
+	"sync"
+
 	"github.com/aoepeople/machine-controller-manager-provider-stackit/pkg/spi"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 )
 
 // Provider is the struct that implements the driver interface
 // It is used to implement the basic driver functionalities
+//
+// Architecture: Single-tenant design
+// - Each provider instance is deployed per Gardener shoot (cluster)
+// - The STACKIT IaaS client is initialized lazily on first request using credentials from the Secret
+// - All subsequent requests reuse the same client (SDK handles token refresh automatically)
 type Provider struct {
-	SPI    spi.SessionProviderInterface
-	client StackitClient // STACKIT API client (can be mocked for testing)
+	SPI        spi.SessionProviderInterface
+	client     StackitClient // STACKIT API client (can be mocked for testing)
+	clientOnce sync.Once     // Ensures client is initialized exactly once
+	clientErr  error         // Stores initialization error if any
 }
 
 // NewProvider returns an empty provider object
 func NewProvider(spi spi.SessionProviderInterface) driver.Driver {
 	return &Provider{
-		SPI:    spi,
-		client: newSDKStackitClient(), // Initialize SDK client for STACKIT API
+		SPI: spi,
 	}
+}
+
+// ensureClient initializes the STACKIT client on first use (lazy initialization)
+// This is called by all methods that need to interact with STACKIT API
+// Thread-safe via sync.Once
+// If a client is already set (e.g., mock client in tests), initialization is skipped
+func (p *Provider) ensureClient(serviceAccountKey string) error {
+	// If client is already set (e.g., mock client in tests), skip initialization
+	if p.client != nil {
+		return nil
+	}
+
+	p.clientOnce.Do(func() {
+		client, err := NewStackitClient(serviceAccountKey)
+		if err != nil {
+			p.clientErr = fmt.Errorf("failed to initialize STACKIT client: %w", err)
+			return
+		}
+		p.client = client
+	})
+	return p.clientErr
 }

--- a/pkg/provider/sdk_client_test.go
+++ b/pkg/provider/sdk_client_test.go
@@ -503,15 +503,7 @@ var _ = Describe("SDK Type Conversion Helpers", func() {
 		})
 	})
 
-	Describe("createIAASClient", func() {
-		var (
-			client *sdkStackitClient
-		)
-
-		BeforeEach(func() {
-			client = newSDKStackitClient()
-		})
-
+	Describe("NewStackitClient", func() {
 		Context("with STACKIT_NO_AUTH enabled", func() {
 			It("should create client successfully without authentication", func() {
 				// Set environment variable to skip authentication
@@ -525,10 +517,11 @@ var _ = Describe("SDK Type Conversion Helpers", func() {
 					}
 				}()
 
-				iaasClient, err := client.createIAASClient("")
+				client, err := NewStackitClient("")
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(iaasClient).NotTo(BeNil())
+				Expect(client).NotTo(BeNil())
+				Expect(client.iaasClient).NotTo(BeNil())
 			})
 
 			It("should create client with any service account key when no auth is enabled", func() {
@@ -543,10 +536,11 @@ var _ = Describe("SDK Type Conversion Helpers", func() {
 					}
 				}()
 
-				iaasClient, err := client.createIAASClient("invalid-key")
+				client, err := NewStackitClient("invalid-key")
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(iaasClient).NotTo(BeNil())
+				Expect(client).NotTo(BeNil())
+				Expect(client.iaasClient).NotTo(BeNil())
 			})
 		})
 
@@ -570,10 +564,11 @@ var _ = Describe("SDK Type Conversion Helpers", func() {
 					}
 				}()
 
-				iaasClient, err := client.createIAASClient("")
+				client, err := NewStackitClient("")
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(iaasClient).NotTo(BeNil())
+				Expect(client).NotTo(BeNil())
+				Expect(client.iaasClient).NotTo(BeNil())
 			})
 
 			It("should work with default endpoint when STACKIT_API_ENDPOINT is not set", func() {
@@ -593,10 +588,11 @@ var _ = Describe("SDK Type Conversion Helpers", func() {
 					}
 				}()
 
-				iaasClient, err := client.createIAASClient("")
+				client, err := NewStackitClient("")
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(iaasClient).NotTo(BeNil())
+				Expect(client).NotTo(BeNil())
+				Expect(client.iaasClient).NotTo(BeNil())
 			})
 		})
 
@@ -611,10 +607,10 @@ var _ = Describe("SDK Type Conversion Helpers", func() {
 					}
 				}()
 
-				_, err := client.createIAASClient("not-valid-json")
+				_, err := NewStackitClient("not-valid-json")
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to create STACKIT SDK API client"))
+				Expect(err.Error()).To(ContainSubstring("failed to create STACKIT SDK client"))
 			})
 
 			It("should fail with empty service account key", func() {
@@ -627,10 +623,10 @@ var _ = Describe("SDK Type Conversion Helpers", func() {
 					}
 				}()
 
-				_, err := client.createIAASClient("")
+				_, err := NewStackitClient("")
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to create STACKIT SDK API client"))
+				Expect(err.Error()).To(ContainSubstring("failed to create STACKIT SDK client"))
 			})
 
 			It("should fail with valid JSON but missing required fields", func() {
@@ -644,15 +640,15 @@ var _ = Describe("SDK Type Conversion Helpers", func() {
 				}()
 
 				// Valid JSON but not a valid service account key structure
-				_, err := client.createIAASClient(`{"some": "json"}`)
+				_, err := NewStackitClient(`{"some": "json"}`)
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to create STACKIT SDK API client"))
+				Expect(err.Error()).To(ContainSubstring("failed to create STACKIT SDK client"))
 			})
 		})
 
-		Context("stateless client behavior", func() {
-			It("should create new client instance each time", func() {
+		Context("client reusability", func() {
+			It("should create client once and reuse IaaS client", func() {
 				// Use STACKIT_NO_AUTH to avoid needing valid credentials
 				originalNoAuth := os.Getenv("STACKIT_NO_AUTH")
 				os.Setenv("STACKIT_NO_AUTH", "true")
@@ -664,8 +660,8 @@ var _ = Describe("SDK Type Conversion Helpers", func() {
 					}
 				}()
 
-				client1, err1 := client.createIAASClient("")
-				client2, err2 := client.createIAASClient("")
+				client1, err1 := NewStackitClient("")
+				client2, err2 := NewStackitClient("")
 
 				Expect(err1).NotTo(HaveOccurred())
 				Expect(err2).NotTo(HaveOccurred())
@@ -674,21 +670,6 @@ var _ = Describe("SDK Type Conversion Helpers", func() {
 				// Note: We can't easily verify they're different instances without
 				// accessing internal SDK state, but the test documents the intent
 			})
-		})
-	})
-
-	Describe("newSDKStackitClient", func() {
-		It("should create a new SDK client wrapper", func() {
-			client := newSDKStackitClient()
-
-			Expect(client).NotTo(BeNil())
-		})
-
-		It("should create stateless client (no internal state)", func() {
-			client := newSDKStackitClient()
-
-			// The client should be stateless - just a wrapper
-			Expect(client).To(BeAssignableToTypeOf(&sdkStackitClient{}))
 		})
 	})
 

--- a/pkg/provider/stackit_client.go
+++ b/pkg/provider/stackit_client.go
@@ -11,21 +11,22 @@ import (
 // StackitClient is an interface for interacting with STACKIT IAAS API
 // This allows us to mock the client in unit tests
 //
-// Authentication: Uses ServiceAccount Key Flow (STACKIT SDK v1.0.0+)
-// - serviceAccountKey: JSON string containing service account credentials and private key
+// Architecture: Single-tenant design
+// - Each client instance is bound to one STACKIT project via serviceAccountKey
+// - The serviceAccountKey is provided once during client creation (NewStackitClient)
 // - The SDK automatically handles JWT token generation and refresh
 //
 // Note: region parameter is required by STACKIT SDK v1.0.0+
 // It must be extracted from the Secret (e.g., "eu01-1", "eu01-2")
 type StackitClient interface {
 	// CreateServer creates a new server in STACKIT
-	CreateServer(ctx context.Context, serviceAccountKey, projectID, region string, req *CreateServerRequest) (*Server, error)
+	CreateServer(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error)
 	// GetServer retrieves a server by ID from STACKIT
-	GetServer(ctx context.Context, serviceAccountKey, projectID, region, serverID string) (*Server, error)
+	GetServer(ctx context.Context, projectID, region, serverID string) (*Server, error)
 	// DeleteServer deletes a server by ID from STACKIT
-	DeleteServer(ctx context.Context, serviceAccountKey, projectID, region, serverID string) error
+	DeleteServer(ctx context.Context, projectID, region, serverID string) error
 	// ListServers lists all servers in a project
-	ListServers(ctx context.Context, serviceAccountKey, projectID, region string) ([]*Server, error)
+	ListServers(ctx context.Context, projectID, region string) ([]*Server, error)
 }
 
 // CreateServerRequest represents the request to create a server


### PR DESCRIPTION
Only create the iaas client once and use it for all STACKIT connections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lazily initialize and reuse a single STACKIT SDK IaaS client per provider instance, removing per-call credentials and updating core flows, interfaces, tests, and docs.
> 
> - **Provider/Core**:
>   - Add `ensureClient` for lazy, single-tenant client initialization and reuse; warn on credential changes.
>   - Update `CreateMachine`, `DeleteMachine`, `GetMachineStatus`, `ListMachines` to init client once and drop per-call credentials in client invocations.
> - **SDK Client & Interface**:
>   - Introduce `NewStackitClient` with stored `iaasClient`; extract `createIAASClient`.
>   - Change `StackitClient` methods to `CreateServer/GetServer/DeleteServer/ListServers(ctx, projectID, region, ...)` (remove `serviceAccountKey` params).
>   - Implement methods using the persistent SDK client; keep 404 handling via `ErrServerNotFound`.
> - **Tests/Mocks**:
>   - Adjust mocks and all tests to new method signatures and single-client behavior.
> - **Docs**:
>   - README: document single-project binding, lazy init, token refresh, and credential rotation requiring pod restart; clarify env vars.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb448d3d5960e8476567bf8368863ece9bcb2778. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->