### PR TITLE
update cloudprovider secret fields in validation 

### DIFF
--- a/pkg/provider/apis/validation/validation.go
+++ b/pkg/provider/apis/validation/validation.go
@@ -53,22 +53,22 @@ func ValidateProviderSpecNSecret(spec *api.ProviderSpec, secrets *corev1.Secret)
 		return errors // Return early if secret is nil
 	}
 
-	projectID, ok := secrets.Data["projectId"]
+	projectID, ok := secrets.Data["project-id"]
 	if !ok {
-		errors = append(errors, fmt.Errorf("secret field 'projectId' is required"))
+		errors = append(errors, fmt.Errorf("secret field 'project-id' is required"))
 	} else if len(projectID) == 0 {
-		errors = append(errors, fmt.Errorf("secret field 'projectId' cannot be empty"))
+		errors = append(errors, fmt.Errorf("secret field 'project-id' cannot be empty"))
 	} else if !isValidUUID(string(projectID)) {
-		errors = append(errors, fmt.Errorf("secret field 'projectId' must be a valid UUID"))
+		errors = append(errors, fmt.Errorf("secret field 'project-id' must be a valid UUID"))
 	}
 
 	// Validate serviceAccountKey (required for authentication)
 	// ServiceAccount Key Flow: JSON string containing service account credentials and private key
-	serviceAccountKey, ok := secrets.Data["serviceAccountKey"]
+	serviceAccountKey, ok := secrets.Data["serviceaccount.json"]
 	if !ok {
-		errors = append(errors, fmt.Errorf("secret field 'serviceAccountKey' is required"))
+		errors = append(errors, fmt.Errorf("secret field 'serviceaccount.json' is required"))
 	} else if len(serviceAccountKey) == 0 {
-		errors = append(errors, fmt.Errorf("secret field 'serviceAccountKey' cannot be empty"))
+		errors = append(errors, fmt.Errorf("secret field 'serviceaccount.json' cannot be empty"))
 	} else if !isValidJSON(string(serviceAccountKey)) {
 		errors = append(errors, fmt.Errorf("secret field 'serviceAccountKey' must be valid JSON (service account credentials)"))
 	}

--- a/pkg/provider/apis/validation/validation_core_labels_test.go
+++ b/pkg/provider/apis/validation/validation_core_labels_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-				"region":            []byte("eu01-1"),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":              []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/apis/validation/validation_fields_test.go
+++ b/pkg/provider/apis/validation/validation_fields_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-				"region":            []byte("eu01-1"),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":              []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/apis/validation/validation_networking_test.go
+++ b/pkg/provider/apis/validation/validation_networking_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-				"region":            []byte("eu01-1"),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":              []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/apis/validation/validation_secgroup_test.go
+++ b/pkg/provider/apis/validation/validation_secgroup_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-				"region":            []byte("eu01-1"),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":              []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/apis/validation/validation_secret_test.go
+++ b/pkg/provider/apis/validation/validation_secret_test.go
@@ -44,46 +44,46 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 			secret.Data = map[string][]byte{}
 			errors := ValidateProviderSpecNSecret(providerSpec, secret)
 			Expect(errors).NotTo(BeEmpty())
-			Expect(errors[0].Error()).To(ContainSubstring("projectId"))
+			Expect(errors[0].Error()).To(ContainSubstring("project-id"))
 		})
 
 		It("should fail when projectId is empty in secret", func() {
-			secret.Data["projectId"] = []byte("")
+			secret.Data["project-id"] = []byte("")
 			errors := ValidateProviderSpecNSecret(providerSpec, secret)
 			Expect(errors).NotTo(BeEmpty())
-			Expect(errors[0].Error()).To(ContainSubstring("projectId"))
+			Expect(errors[0].Error()).To(ContainSubstring("project-id"))
 		})
 
 		It("should fail when projectId is not a valid UUID", func() {
-			secret.Data["projectId"] = []byte("invalid-uuid")
+			secret.Data["project-id"] = []byte("invalid-uuid")
 			errors := ValidateProviderSpecNSecret(providerSpec, secret)
 			Expect(errors).NotTo(BeEmpty())
-			Expect(errors[0].Error()).To(ContainSubstring("projectId' must be a valid UUID"))
+			Expect(errors[0].Error()).To(ContainSubstring("project-id' must be a valid UUID"))
 		})
 
-		It("should fail when serviceAccountKey is missing from secret", func() {
-			delete(secret.Data, "serviceAccountKey")
+		It("should fail when serviceaccount.json is missing from secret", func() {
+			delete(secret.Data, "serviceaccount.json")
 			errors := ValidateProviderSpecNSecret(providerSpec, secret)
 			Expect(errors).NotTo(BeEmpty())
-			Expect(errors[0].Error()).To(ContainSubstring("serviceAccountKey"))
+			Expect(errors[0].Error()).To(ContainSubstring("serviceaccount.json"))
 		})
 
-		It("should fail when serviceAccountKey is empty in secret", func() {
-			secret.Data["serviceAccountKey"] = []byte("")
+		It("should fail when serviceaccount.json is empty in secret", func() {
+			secret.Data["serviceaccount.json"] = []byte("")
 			errors := ValidateProviderSpecNSecret(providerSpec, secret)
 			Expect(errors).NotTo(BeEmpty())
-			Expect(errors[0].Error()).To(ContainSubstring("serviceAccountKey"))
+			Expect(errors[0].Error()).To(ContainSubstring("serviceaccount.json"))
 		})
 
-		It("should fail when serviceAccountKey is not valid JSON", func() {
-			secret.Data["serviceAccountKey"] = []byte("not-valid-json")
+		It("should fail when serviceaccount.json is not valid JSON", func() {
+			secret.Data["serviceaccount.json"] = []byte("not-valid-json")
 			errors := ValidateProviderSpecNSecret(providerSpec, secret)
 			Expect(errors).NotTo(BeEmpty())
 			Expect(errors[0].Error()).To(ContainSubstring("must be valid JSON"))
 		})
 
-		It("should fail when serviceAccountKey is malformed JSON (missing closing brace)", func() {
-			secret.Data["serviceAccountKey"] = []byte(`{"credentials":{"iss":"test"`)
+		It("should fail when serviceaccount.json is malformed JSON (missing closing brace)", func() {
+			secret.Data["serviceaccount.json"] = []byte(`{"credentials":{"iss":"test"`)
 			errors := ValidateProviderSpecNSecret(providerSpec, secret)
 			Expect(errors).NotTo(BeEmpty())
 			Expect(errors[0].Error()).To(ContainSubstring("must be valid JSON"))

--- a/pkg/provider/apis/validation/validation_secret_test.go
+++ b/pkg/provider/apis/validation/validation_secret_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-				"region":            []byte("eu01-1"),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":              []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/apis/validation/validation_volumes_test.go
+++ b/pkg/provider/apis/validation/validation_volumes_test.go
@@ -26,9 +26,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-				"region":            []byte("eu01-1"),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":              []byte("eu01-1"),
 			},
 		}
 	})

--- a/pkg/provider/core.go
+++ b/pkg/provider/core.go
@@ -51,8 +51,8 @@ func (p *Provider) CreateMachine(ctx context.Context, req *driver.CreateMachineR
 	}
 
 	// Extract credentials from Secret
-	projectID := string(req.Secret.Data["projectId"])
-	serviceAccountKey := string(req.Secret.Data["serviceAccountKey"])
+	projectID := string(req.Secret.Data["project-id"])
+	serviceAccountKey := string(req.Secret.Data["serviceaccount.json"])
 	region := string(req.Secret.Data["region"])
 
 	// Initialize client on first use (lazy initialization)
@@ -210,7 +210,7 @@ func (p *Provider) DeleteMachine(ctx context.Context, req *driver.DeleteMachineR
 	}
 
 	// Extract credentials from Secret
-	serviceAccountKey := string(req.Secret.Data["serviceAccountKey"])
+	serviceAccountKey := string(req.Secret.Data["serviceaccount.json"])
 	region := string(req.Secret.Data["region"])
 
 	// Initialize client on first use (lazy initialization)
@@ -220,6 +220,9 @@ func (p *Provider) DeleteMachine(ctx context.Context, req *driver.DeleteMachineR
 
 	// Parse ProviderID to extract projectID and serverID
 	projectID, serverID, err := parseProviderID(req.Machine.Spec.ProviderID)
+	if projectID == "" {
+		projectID = string(req.Secret.Data["project-id"])
+	}
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid ProviderID format: %v", err))
 	}
@@ -269,7 +272,7 @@ func (p *Provider) GetMachineStatus(ctx context.Context, req *driver.GetMachineS
 	}
 
 	// Extract credentials from Secret
-	serviceAccountKey := string(req.Secret.Data["serviceAccountKey"])
+	serviceAccountKey := string(req.Secret.Data["serviceaccount.json"])
 	region := string(req.Secret.Data["region"])
 
 	// Initialize client on first use (lazy initialization)
@@ -280,6 +283,9 @@ func (p *Provider) GetMachineStatus(ctx context.Context, req *driver.GetMachineS
 	// Parse ProviderID to extract projectID and serverID
 	// Expected format: stackit://<projectId>/<serverId>
 	projectID, serverID, err := parseProviderID(req.Machine.Spec.ProviderID)
+	if projectID == "" {
+		projectID = string(req.Secret.Data["project-id"])
+	}
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid ProviderID format: %v", err))
 	}
@@ -322,8 +328,8 @@ func (p *Provider) ListMachines(ctx context.Context, req *driver.ListMachinesReq
 	defer klog.V(2).Infof("List machines request has been processed for %q", req.MachineClass.Name)
 
 	// Extract credentials from Secret
-	projectID := string(req.Secret.Data["projectId"])
-	serviceAccountKey := string(req.Secret.Data["serviceAccountKey"])
+	projectID := string(req.Secret.Data["project-id"])
+	serviceAccountKey := string(req.Secret.Data["serviceaccount.json"])
 	region := string(req.Secret.Data["region"])
 
 	// Initialize client on first use (lazy initialization)

--- a/pkg/provider/core_create_machine_basic_test.go
+++ b/pkg/provider/core_create_machine_basic_test.go
@@ -41,10 +41,10 @@ var _ = Describe("CreateMachine", func() {
 		// Create secret with projectId and networkId (required for v2 API)
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-				"region":            []byte("eu01-1"),
-				"networkId":         []byte("770e8400-e29b-41d4-a716-446655440000"),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":              []byte("eu01-1"),
+				"networkId":           []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},
 		}
 

--- a/pkg/provider/core_create_machine_config_test.go
+++ b/pkg/provider/core_create_machine_config_test.go
@@ -38,10 +38,10 @@ var _ = Describe("CreateMachine", func() {
 		// Create secret with projectId and networkId (required for v2 API)
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-				"region":            []byte("eu01-1"),
-				"networkId":         []byte("770e8400-e29b-41d4-a716-446655440000"),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":              []byte("eu01-1"),
+				"networkId":           []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},
 		}
 

--- a/pkg/provider/core_create_machine_networking_test.go
+++ b/pkg/provider/core_create_machine_networking_test.go
@@ -38,9 +38,9 @@ var _ = Describe("CreateMachine - Networking", func() {
 		// Create secret with basic required fields
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-				"region":            []byte("eu01-1"),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":              []byte("eu01-1"),
 			},
 		}
 

--- a/pkg/provider/core_create_machine_storage_test.go
+++ b/pkg/provider/core_create_machine_storage_test.go
@@ -38,10 +38,10 @@ var _ = Describe("CreateMachine", func() {
 		// Create secret with projectId and networkId (required for v2 API)
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-				"region":            []byte("eu01-1"),
-				"networkId":         []byte("770e8400-e29b-41d4-a716-446655440000"),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":              []byte("eu01-1"),
+				"networkId":           []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},
 		}
 

--- a/pkg/provider/core_create_machine_userdata_test.go
+++ b/pkg/provider/core_create_machine_userdata_test.go
@@ -39,10 +39,10 @@ var _ = Describe("CreateMachine", func() {
 		// Create secret with projectId and networkId (required for v2 API)
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
-				"region":            []byte("eu01-1"),
-				"networkId":         []byte("770e8400-e29b-41d4-a716-446655440000"),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
+				"region":              []byte("eu01-1"),
+				"networkId":           []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},
 		}
 

--- a/pkg/provider/core_list_machines_test.go
+++ b/pkg/provider/core_list_machines_test.go
@@ -40,8 +40,8 @@ var _ = Describe("ListMachines", func() {
 		// Create secret with projectId
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				"projectId":         []byte("11111111-2222-3333-4444-555555555555"),
-				"serviceAccountKey": []byte(`{"credentials":{"iss":"test"}}`),
+				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
+				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
 			},
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:

This PR updates the cloudprovider secret fields for validations.


**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
