### PR TITLE
try fetching server before creating

### DIFF
--- a/pkg/provider/core.go
+++ b/pkg/provider/core.go
@@ -18,6 +18,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const STACKIT_PROVIDER = "stackit"
+
 // CreateMachine handles a machine creation request by creating a STACKIT server
 //
 // This method creates a new server in STACKIT infrastructure based on the ProviderSpec
@@ -37,6 +39,12 @@ func (p *Provider) CreateMachine(ctx context.Context, req *driver.CreateMachineR
 	// Log messages to track request
 	klog.V(2).Infof("Machine creation request has been received for %q", req.Machine.Name)
 	defer klog.V(2).Infof("Machine creation request has been processed for %q", req.Machine.Name)
+
+	// Check if incoming provider in the MachineClass is a provider we support
+	if req.MachineClass.Provider != STACKIT_PROVIDER {
+		err := fmt.Errorf("requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, STACKIT_PROVIDER)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	// Decode ProviderSpec from MachineClass
 	providerSpec, err := decodeProviderSpec(req.MachineClass)
@@ -177,7 +185,7 @@ func (p *Provider) CreateMachine(ctx context.Context, req *driver.CreateMachineR
 	}
 
 	// Generate ProviderID in format: stackit://<projectId>/<serverId>
-	providerID := fmt.Sprintf("stackit://%s/%s", projectID, server.ID)
+	providerID := fmt.Sprintf("%s://%s/%s", STACKIT_PROVIDER, projectID, server.ID)
 
 	// NodeName is the machine name (will register with this name in Kubernetes)
 	nodeName := req.Machine.Name
@@ -351,7 +359,8 @@ func (p *Provider) ListMachines(ctx context.Context, req *driver.ListMachinesReq
 	}
 
 	// Call STACKIT API to list all servers
-	servers, err := p.client.ListServers(ctx, projectID, providerSpec.Region)
+	labelSelector := "mcm.gardener.cloud/machineclass=" + req.MachineClass.Name
+	servers, err := p.client.ListServers(ctx, projectID, providerSpec.Region, labelSelector)
 	if err != nil {
 		klog.Errorf("Failed to list servers for MachineClass %q: %v", req.MachineClass.Name, err)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to list servers: %v", err))
@@ -361,26 +370,16 @@ func (p *Provider) ListMachines(ctx context.Context, req *driver.ListMachinesReq
 	// We use the "mcm.gardener.cloud/machineclass" label to identify which servers belong to this MachineClass
 	machineList := make(map[string]string)
 	for _, server := range servers {
-		// Skip servers without labels
-		if server.Labels == nil {
-			continue
+		// Generate ProviderID in format: stackit://<projectId>/<serverId>
+		providerID := fmt.Sprintf("stackit://%s/%s", projectID, server.ID)
+
+		// Get machine name from labels (fallback to server name if not found)
+		machineName := server.Name
+		if machineLabel, ok := server.Labels["mcm.gardener.cloud/machine"]; ok {
+			machineName = machineLabel
 		}
 
-		// Check if server has the matching MachineClass label
-		if machineClassLabel, ok := server.Labels["mcm.gardener.cloud/machineclass"]; ok {
-			if machineClassLabel == req.MachineClass.Name {
-				// Generate ProviderID in format: stackit://<projectId>/<serverId>
-				providerID := fmt.Sprintf("stackit://%s/%s", projectID, server.ID)
-
-				// Get machine name from labels (fallback to server name if not found)
-				machineName := server.Name
-				if machineLabel, ok := server.Labels["mcm.gardener.cloud/machine"]; ok {
-					machineName = machineLabel
-				}
-
-				machineList[providerID] = machineName
-			}
-		}
+		machineList[providerID] = machineName
 	}
 
 	klog.V(2).Infof("Found %d machines for MachineClass %q", len(machineList), req.MachineClass.Name)

--- a/pkg/provider/core.go
+++ b/pkg/provider/core.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const STACKIT_PROVIDER = "stackit"
+const StackitProviderName = "stackit"
 
 // CreateMachine handles a machine creation request by creating a STACKIT server
 //
@@ -41,8 +41,8 @@ func (p *Provider) CreateMachine(ctx context.Context, req *driver.CreateMachineR
 	defer klog.V(2).Infof("Machine creation request has been processed for %q", req.Machine.Name)
 
 	// Check if incoming provider in the MachineClass is a provider we support
-	if req.MachineClass.Provider != STACKIT_PROVIDER {
-		err := fmt.Errorf("requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, STACKIT_PROVIDER)
+	if req.MachineClass.Provider != StackitProviderName {
+		err := fmt.Errorf("requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, StackitProviderName)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -185,7 +185,7 @@ func (p *Provider) CreateMachine(ctx context.Context, req *driver.CreateMachineR
 	}
 
 	// Generate ProviderID in format: stackit://<projectId>/<serverId>
-	providerID := fmt.Sprintf("%s://%s/%s", STACKIT_PROVIDER, projectID, server.ID)
+	providerID := fmt.Sprintf("%s://%s/%s", StackitProviderName, projectID, server.ID)
 
 	// NodeName is the machine name (will register with this name in Kubernetes)
 	nodeName := req.Machine.Name

--- a/pkg/provider/core.go
+++ b/pkg/provider/core.go
@@ -364,7 +364,7 @@ func (p *Provider) ListMachines(ctx context.Context, req *driver.ListMachinesReq
 	}
 
 	// Call STACKIT API to list all servers
-	labelSelector := StackitMachineClassLabel + "=" + req.MachineClass.Name
+	labelSelector := fmt.Sprintf("%s=%s", StackitMachineClassLabel, req.MachineClass.Name)
 	servers, err := p.client.ListServers(ctx, projectID, providerSpec.Region, labelSelector)
 	if err != nil {
 		klog.Errorf("Failed to list servers for MachineClass %q: %v", req.MachineClass.Name, err)

--- a/pkg/provider/core_create_machine_basic_test.go
+++ b/pkg/provider/core_create_machine_basic_test.go
@@ -60,6 +60,7 @@ var _ = Describe("CreateMachine", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-machine-class",
 			},
+			Provider: "stackit",
 			ProviderSpec: runtime.RawExtension{
 				Raw: providerSpecRaw,
 			},
@@ -147,6 +148,15 @@ var _ = Describe("CreateMachine", func() {
 			statusErr, ok := status.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(statusErr.Code()).To(Equal(codes.InvalidArgument))
+		})
+
+		It("should fail when Provider is wrong", func() {
+			req.MachineClass.Provider = "openstack"
+
+			_, err := provider.CreateMachine(ctx, req)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("requested for Provider 'openstack', we only support 'stackit'"))
 		})
 	})
 

--- a/pkg/provider/core_create_machine_config_test.go
+++ b/pkg/provider/core_create_machine_config_test.go
@@ -57,6 +57,7 @@ var _ = Describe("CreateMachine", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-machine-class",
 			},
+			Provider: "stackit",
 			ProviderSpec: runtime.RawExtension{
 				Raw: providerSpecRaw,
 			},

--- a/pkg/provider/core_create_machine_networking_test.go
+++ b/pkg/provider/core_create_machine_networking_test.go
@@ -68,6 +68,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-machine-class",
 				},
+				Provider: "stackit",
 				ProviderSpec: runtime.RawExtension{
 					Raw: providerSpecRaw,
 				},
@@ -115,6 +116,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-machine-class",
 				},
+				Provider: "stackit",
 				ProviderSpec: runtime.RawExtension{
 					Raw: providerSpecRaw,
 				},
@@ -164,6 +166,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-machine-class",
 				},
+				Provider: "stackit",
 				ProviderSpec: runtime.RawExtension{
 					Raw: providerSpecRaw,
 				},
@@ -206,6 +209,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-machine-class",
 				},
+				Provider: "stackit",
 				ProviderSpec: runtime.RawExtension{
 					Raw: providerSpecRaw,
 				},
@@ -255,6 +259,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-machine-class",
 				},
+				Provider: "stackit",
 				ProviderSpec: runtime.RawExtension{
 					Raw: providerSpecRaw,
 				},
@@ -302,6 +307,7 @@ var _ = Describe("CreateMachine - Networking", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-machine-class",
 				},
+				Provider: "stackit",
 				ProviderSpec: runtime.RawExtension{
 					Raw: providerSpecRaw,
 				},

--- a/pkg/provider/core_create_machine_storage_test.go
+++ b/pkg/provider/core_create_machine_storage_test.go
@@ -57,6 +57,7 @@ var _ = Describe("CreateMachine", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-machine-class",
 			},
+			Provider: "stackit",
 			ProviderSpec: runtime.RawExtension{
 				Raw: providerSpecRaw,
 			},

--- a/pkg/provider/core_create_machine_userdata_test.go
+++ b/pkg/provider/core_create_machine_userdata_test.go
@@ -58,6 +58,7 @@ var _ = Describe("CreateMachine", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-machine-class",
 			},
+			Provider: "stackit",
 			ProviderSpec: runtime.RawExtension{
 				Raw: providerSpecRaw,
 			},

--- a/pkg/provider/core_mocks_test.go
+++ b/pkg/provider/core_mocks_test.go
@@ -16,7 +16,7 @@ type mockStackitClient struct {
 	createServerFunc func(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error)
 	getServerFunc    func(ctx context.Context, projectID, region, serverID string) (*Server, error)
 	deleteServerFunc func(ctx context.Context, projectID, region, serverID string) error
-	listServersFunc  func(ctx context.Context, projectID, region string) ([]*Server, error)
+	listServersFunc  func(ctx context.Context, projectID, region, labelSelector string) ([]*Server, error)
 }
 
 func (m *mockStackitClient) CreateServer(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
@@ -48,9 +48,9 @@ func (m *mockStackitClient) DeleteServer(ctx context.Context, projectID, region,
 	return nil
 }
 
-func (m *mockStackitClient) ListServers(ctx context.Context, projectID, region string) ([]*Server, error) {
+func (m *mockStackitClient) ListServers(ctx context.Context, projectID, region, labelSelector string) ([]*Server, error) {
 	if m.listServersFunc != nil {
-		return m.listServersFunc(ctx, projectID, region)
+		return m.listServersFunc(ctx, projectID, region, labelSelector)
 	}
 	return []*Server{}, nil
 }

--- a/pkg/provider/sdk_client.go
+++ b/pkg/provider/sdk_client.go
@@ -87,7 +87,7 @@ func createIAASClient(serviceAccountKey string) (*iaas.APIClient, error) {
 
 // CreateServer creates a new server via STACKIT SDK
 //
-//nolint:gocyclo//TODO:refactor
+//nolint:gocyclo,funlen//TODO:refactor
 func (c *SdkStackitClient) CreateServer(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 	// Check if the server got already created
 	labelSelector := "mcm.gardener.cloud/machine=" + req.Name

--- a/pkg/provider/sdk_client.go
+++ b/pkg/provider/sdk_client.go
@@ -90,7 +90,7 @@ func createIAASClient(serviceAccountKey string) (*iaas.APIClient, error) {
 //nolint:gocyclo,funlen//TODO:refactor
 func (c *SdkStackitClient) CreateServer(ctx context.Context, projectID, region string, req *CreateServerRequest) (*Server, error) {
 	// Check if the server got already created
-	labelSelector := "mcm.gardener.cloud/machine=" + req.Name
+	labelSelector := fmt.Sprintf("mcm.gardener.cloud/machine=%s", req.Name)
 	servers, err := c.ListServers(ctx, projectID, region, labelSelector)
 	if err != nil {
 		return nil, fmt.Errorf("SDK ListServers with labelSelector: %v failed: %w", labelSelector, err)

--- a/pkg/provider/sdk_client.go
+++ b/pkg/provider/sdk_client.go
@@ -277,7 +277,7 @@ func (c *SdkStackitClient) ListServers(ctx context.Context, projectID, region, l
 	serverRequest := c.iaasClient.ListServers(ctx, projectID, region)
 
 	if labelSelector != "" {
-		serverRequest.LabelSelector(labelSelector)
+		serverRequest = serverRequest.LabelSelector(labelSelector)
 	}
 
 	sdkResponse, err := serverRequest.Execute()

--- a/pkg/provider/stackit_client.go
+++ b/pkg/provider/stackit_client.go
@@ -26,7 +26,7 @@ type StackitClient interface {
 	// DeleteServer deletes a server by ID from STACKIT
 	DeleteServer(ctx context.Context, projectID, region, serverID string) error
 	// ListServers lists all servers in a project
-	ListServers(ctx context.Context, projectID, region string) ([]*Server, error)
+	ListServers(ctx context.Context, projectID, region, labelSelector string) ([]*Server, error)
 }
 
 // CreateServerRequest represents the request to create a server


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:  
When creating new clusters sometimes the mcm will create 2 server with the same name. These kubelets are then fighting for the same Node CR.

The Openstack MCM is doing a similar thing.

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
