### PR TITLE
fix trailing comma for label selector

### DIFF
--- a/pkg/provider/sdk_client.go
+++ b/pkg/provider/sdk_client.go
@@ -265,7 +265,11 @@ func (c *SdkStackitClient) ListServers(ctx context.Context, projectID, region st
 	if labelSelector != nil {
 		sb := strings.Builder{}
 		for k, v := range labelSelector {
-			_, err := fmt.Fprintf(&sb, "%s=%s,", k, v)
+			// prevents trailing comma at the end
+			if sb.Len() > 0 {
+				sb.WriteString(",")
+			}
+			_, err := fmt.Fprintf(&sb, "%s=%s", k, v)
 			if err != nil {
 				return nil, fmt.Errorf("failed to format label selector: %w", err)
 			}


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The iaas api expects a valid label selector after a comma. The change made it through at the very last time in review so it was not properly tested.

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
