### PR TITLE
Declutter secret

### DIFF
--- a/pkg/provider/apis/validation/validation.go
+++ b/pkg/provider/apis/validation/validation.go
@@ -124,8 +124,10 @@ func ValidateProviderSpecNSecret(spec *api.ProviderSpec, secrets *corev1.Secret)
 		}
 	}
 
-	// Validate Networking
-	if spec.Networking != nil {
+	// Validate Networking (required)
+	if spec.Networking == nil {
+		errors = append(errors, fmt.Errorf("providerSpec.networking is required"))
+	} else {
 		networkingErrors := validateNetworking(spec.Networking)
 		errors = append(errors, networkingErrors...)
 	}

--- a/pkg/provider/apis/validation/validation_core_labels_test.go
+++ b/pkg/provider/apis/validation/validation_core_labels_test.go
@@ -20,6 +20,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 			MachineType: "c2i.2",
 			ImageID:     "550e8400-e29b-41d4-a716-446655440000",
 			Region:      "eu01",
+			Networking: &api.NetworkingSpec{
+				NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+			},
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
@@ -72,8 +75,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 		It("should fail when both required fields are empty", func() {
 			providerSpec.MachineType = ""
 			providerSpec.ImageID = ""
+			providerSpec.Networking = nil
 			errors := ValidateProviderSpecNSecret(providerSpec, secret)
-			Expect(errors).To(HaveLen(2))
+			Expect(errors).To(HaveLen(3))
 		})
 
 		It("should succeed when Labels is nil", func() {

--- a/pkg/provider/apis/validation/validation_fields_test.go
+++ b/pkg/provider/apis/validation/validation_fields_test.go
@@ -20,6 +20,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 			MachineType: "c2i.2",
 			ImageID:     "550e8400-e29b-41d4-a716-446655440000",
 			Region:      "eu01",
+			Networking: &api.NetworkingSpec{
+				NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+			},
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{

--- a/pkg/provider/apis/validation/validation_networking_test.go
+++ b/pkg/provider/apis/validation/validation_networking_test.go
@@ -49,10 +49,11 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 			Expect(errors).To(BeEmpty())
 		})
 
-		It("should succeed when Networking is nil", func() {
+		It("should fail when Networking is nil", func() {
 			providerSpec.Networking = nil
 			errors := ValidateProviderSpecNSecret(providerSpec, secret)
-			Expect(errors).To(BeEmpty())
+			Expect(errors).NotTo(BeEmpty())
+			Expect(errors[0].Error()).To(ContainSubstring("networking is required"))
 		})
 
 		It("should fail when Networking has neither NetworkID nor NICIDs", func() {

--- a/pkg/provider/apis/validation/validation_secgroup_test.go
+++ b/pkg/provider/apis/validation/validation_secgroup_test.go
@@ -20,6 +20,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 			MachineType: "c2i.2",
 			ImageID:     "550e8400-e29b-41d4-a716-446655440000",
 			Region:      "eu01",
+			Networking: &api.NetworkingSpec{
+				NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+			},
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{

--- a/pkg/provider/apis/validation/validation_secret_test.go
+++ b/pkg/provider/apis/validation/validation_secret_test.go
@@ -20,6 +20,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 			MachineType: "c2i.2",
 			ImageID:     "550e8400-e29b-41d4-a716-446655440000",
 			Region:      "eu01",
+			Networking: &api.NetworkingSpec{
+				NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+			},
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{

--- a/pkg/provider/apis/validation/validation_volumes_test.go
+++ b/pkg/provider/apis/validation/validation_volumes_test.go
@@ -20,6 +20,9 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 			MachineType: "c2i.2",
 			ImageID:     "550e8400-e29b-41d4-a716-446655440000",
 			Region:      "eu01",
+			Networking: &api.NetworkingSpec{
+				NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+			},
 		}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{

--- a/pkg/provider/create.go
+++ b/pkg/provider/create.go
@@ -90,7 +90,7 @@ func (p *Provider) CreateMachine(ctx context.Context, req *driver.CreateMachineR
 	}, nil
 }
 
-//nolint:gocyclo // TODO: will be fixed next PR
+// nolint: gocyclo // this function is already pretty simple
 func (p *Provider) createServerRequest(req *driver.CreateMachineRequest, providerSpec *api.ProviderSpec) *client.CreateServerRequest {
 	// Build labels: merge ProviderSpec labels with MCM-specific labels
 	labels := make(map[string]string)
@@ -114,18 +114,10 @@ func (p *Provider) createServerRequest(req *driver.CreateMachineRequest, provide
 	}
 
 	// Add networking configuration (required in v2 API)
-	// If not specified in ProviderSpec, try to use networkId from Secret, or use empty
 	if providerSpec.Networking != nil {
 		createReq.Networking = &client.ServerNetworkingRequest{
 			NetworkID: providerSpec.Networking.NetworkID,
 			NICIDs:    providerSpec.Networking.NICIDs,
-		}
-	} else {
-		// v2 API requires networking field - use networkId from Secret if available
-		// This allows tests/deployments to specify a default network without modifying each MachineClass
-		networkID := string(req.Secret.Data["networkId"])
-		createReq.Networking = &client.ServerNetworkingRequest{
-			NetworkID: networkID, // Can be empty string if not in Secret
 		}
 	}
 

--- a/pkg/provider/create_basic_test.go
+++ b/pkg/provider/create_basic_test.go
@@ -36,12 +36,10 @@ var _ = Describe("CreateMachine", func() {
 			client: mockClient,
 		}
 
-		// Create secret with projectId and networkId (required for v2 API)
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
 				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
-				"networkId":           []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},
 		}
 
@@ -50,6 +48,9 @@ var _ = Describe("CreateMachine", func() {
 			MachineType: "c2i.2",
 			ImageID:     "12345678-1234-1234-1234-123456789abc",
 			Region:      "eu01",
+			Networking: &api.NetworkingSpec{
+				NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+			},
 		}
 		providerSpecRaw, _ := mock.EncodeProviderSpec(providerSpec)
 

--- a/pkg/provider/create_config_test.go
+++ b/pkg/provider/create_config_test.go
@@ -33,12 +33,10 @@ var _ = Describe("CreateMachine", func() {
 			client: mockClient,
 		}
 
-		// Create secret with projectId and networkId (required for v2 API)
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
 				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
-				"networkId":           []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},
 		}
 
@@ -47,6 +45,9 @@ var _ = Describe("CreateMachine", func() {
 			MachineType: "c2i.2",
 			ImageID:     "12345678-1234-1234-1234-123456789abc",
 			Region:      "eu01",
+			Networking: &api.NetworkingSpec{
+				NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+			},
 		}
 		providerSpecRaw, _ := mock.EncodeProviderSpec(providerSpec)
 
@@ -82,6 +83,9 @@ var _ = Describe("CreateMachine", func() {
 			providerSpec := &api.ProviderSpec{
 				MachineType: "c2i.2",
 				Region:      "eu01",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
 				ImageID:     "12345678-1234-1234-1234-123456789abc",
 				KeypairName: "my-ssh-key",
 			}
@@ -127,9 +131,12 @@ var _ = Describe("CreateMachine", func() {
 	Context("with availabilityZone", func() {
 		It("should pass AvailabilityZone to API when specified", func() {
 			providerSpec := &api.ProviderSpec{
-				MachineType:      "c2i.2",
-				ImageID:          "12345678-1234-1234-1234-123456789abc",
-				Region:           "eu01",
+				MachineType: "c2i.2",
+				ImageID:     "12345678-1234-1234-1234-123456789abc",
+				Region:      "eu01",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
 				AvailabilityZone: "eu01-1",
 			}
 			providerSpecRaw, _ := mock.EncodeProviderSpec(providerSpec)
@@ -174,8 +181,11 @@ var _ = Describe("CreateMachine", func() {
 	Context("with affinityGroup", func() {
 		It("should pass AffinityGroup to API when specified", func() {
 			providerSpec := &api.ProviderSpec{
-				MachineType:   "c2i.2",
-				Region:        "eu01",
+				MachineType: "c2i.2",
+				Region:      "eu01",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
 				ImageID:       "12345678-1234-1234-1234-123456789abc",
 				AffinityGroup: "880e8400-e29b-41d4-a716-446655440000",
 			}
@@ -221,7 +231,10 @@ var _ = Describe("CreateMachine", func() {
 			providerSpec := &api.ProviderSpec{
 				MachineType: "c2i.2",
 				Region:      "eu01",
-				ImageID:     "12345678-1234-1234-1234-123456789abc",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
+				ImageID: "12345678-1234-1234-1234-123456789abc",
 				ServiceAccountMails: []string{
 					"my-service@sa.stackit.cloud",
 				},
@@ -272,6 +285,9 @@ var _ = Describe("CreateMachine", func() {
 				MachineType: "c2i.2",
 				ImageID:     "12345678-1234-1234-1234-123456789abc",
 				Region:      "eu01",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
 				Agent: &api.AgentSpec{
 					Provisioned: &provisioned,
 				},
@@ -319,7 +335,10 @@ var _ = Describe("CreateMachine", func() {
 			providerSpec := &api.ProviderSpec{
 				MachineType: "c2i.2",
 				Region:      "eu01",
-				ImageID:     "12345678-1234-1234-1234-123456789abc",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
+				ImageID: "12345678-1234-1234-1234-123456789abc",
 				Metadata: map[string]interface{}{
 					"environment": "production",
 					"cost-center": "12345",

--- a/pkg/provider/create_storage_test.go
+++ b/pkg/provider/create_storage_test.go
@@ -33,12 +33,10 @@ var _ = Describe("CreateMachine", func() {
 			client: mockClient,
 		}
 
-		// Create secret with projectId and networkId (required for v2 API)
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
 				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
-				"networkId":           []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},
 		}
 
@@ -47,6 +45,9 @@ var _ = Describe("CreateMachine", func() {
 			MachineType: "c2i.2",
 			ImageID:     "12345678-1234-1234-1234-123456789abc",
 			Region:      "eu01",
+			Networking: &api.NetworkingSpec{
+				NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+			},
 		}
 		providerSpecRaw, _ := mock.EncodeProviderSpec(providerSpec)
 
@@ -84,6 +85,9 @@ var _ = Describe("CreateMachine", func() {
 				MachineType: "c2i.2",
 				ImageID:     "12345678-1234-1234-1234-123456789abc",
 				Region:      "eu01",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
 				BootVolume: &api.BootVolumeSpec{
 					DeleteOnTermination: &deleteOnTermination,
 					PerformanceClass:    "premium",
@@ -125,6 +129,9 @@ var _ = Describe("CreateMachine", func() {
 				MachineType: "c2i.2",
 				ImageID:     "12345678-1234-1234-1234-123456789abc",
 				Region:      "eu01",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
 				BootVolume: &api.BootVolumeSpec{
 					Size: 50,
 				},
@@ -155,6 +162,9 @@ var _ = Describe("CreateMachine", func() {
 				MachineType: "c2i.2",
 				ImageID:     "12345678-1234-1234-1234-123456789abc",
 				Region:      "eu01",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
 				Volumes: []string{
 					"550e8400-e29b-41d4-a716-446655440000",
 					"660e8400-e29b-41d4-a716-446655440001",
@@ -188,6 +198,9 @@ var _ = Describe("CreateMachine", func() {
 				MachineType: "c2i.2",
 				ImageID:     "12345678-1234-1234-1234-123456789abc",
 				Region:      "eu01",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
 				BootVolume: &api.BootVolumeSpec{
 					Size: 50,
 				},

--- a/pkg/provider/create_userdata_test.go
+++ b/pkg/provider/create_userdata_test.go
@@ -34,12 +34,10 @@ var _ = Describe("CreateMachine", func() {
 			client: mockClient,
 		}
 
-		// Create secret with projectId and networkId (required for v2 API)
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
 				"project-id":          []byte("11111111-2222-3333-4444-555555555555"),
 				"serviceaccount.json": []byte(`{"credentials":{"iss":"test"}}`),
-				"networkId":           []byte("770e8400-e29b-41d4-a716-446655440000"),
 			},
 		}
 
@@ -48,6 +46,9 @@ var _ = Describe("CreateMachine", func() {
 			MachineType: "c2i.2",
 			ImageID:     "12345678-1234-1234-1234-123456789abc",
 			Region:      "eu01",
+			Networking: &api.NetworkingSpec{
+				NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+			},
 		}
 		providerSpecRaw, _ := mock.EncodeProviderSpec(providerSpec)
 
@@ -85,6 +86,9 @@ var _ = Describe("CreateMachine", func() {
 				ImageID:     "12345678-1234-1234-1234-123456789abc",
 				UserData:    "#cloud-config\nruncmd:\n  - echo 'Hello from ProviderSpec'",
 				Region:      "eu01",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
 			}
 			providerSpecRaw, _ := mock.EncodeProviderSpec(providerSpec)
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw
@@ -134,6 +138,9 @@ var _ = Describe("CreateMachine", func() {
 				ImageID:     "12345678-1234-1234-1234-123456789abc",
 				UserData:    "#cloud-config from ProviderSpec",
 				Region:      "eu01",
+				Networking: &api.NetworkingSpec{
+					NetworkID: "770e8400-e29b-41d4-a716-446655440000",
+				},
 			}
 			providerSpecRaw, _ := mock.EncodeProviderSpec(providerSpec)
 			req.MachineClass.ProviderSpec.Raw = providerSpecRaw

--- a/samples/machine-class.yaml
+++ b/samples/machine-class.yaml
@@ -130,8 +130,8 @@ providerSpec:
   # Volumes: attach existing volumes by UUID
   # These are data volumes in addition to the boot disk
   volumes:
-    - "880e8400-e29b-41d4-a716-446655440000"  # data-volume-1
-    - "990e8400-e29b-41d4-a716-446655440001"  # data-volume-2
+    - "880e8400-e29b-41d4-a716-446655440000" # data-volume-1
+    - "990e8400-e29b-41d4-a716-446655440001" # data-volume-2
 secretRef:
   name: test-secret
   namespace: default

--- a/test/e2e/e2e_affinity_test.go
+++ b/test/e2e/e2e_affinity_test.go
@@ -28,7 +28,6 @@ var _ = Describe("MCM Provider STACKIT", func() {
     projectId: "12345678-1234-1234-1234-123456789012"
     serviceAccountKey: "{}"
     region: "eu01-1"
-    networkId: "770e8400-e29b-41d4-a716-446655440000"
     userData: |
       #cloud-config
       runcmd:
@@ -46,6 +45,8 @@ var _ = Describe("MCM Provider STACKIT", func() {
   providerSpec:
     machineType: "c2i.2"
     imageId: "550e8400-e29b-41d4-a716-446655440000"
+    networking:
+      networkId: "770e8400-e29b-41d4-a716-446655440000"
     affinityGroup: "880e8400-e29b-41d4-a716-446655440000"
   secretRef:
     name: %s

--- a/test/e2e/e2e_agent_test.go
+++ b/test/e2e/e2e_agent_test.go
@@ -28,7 +28,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -46,6 +45,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   agent:
     provisioned: true
 secretRef:

--- a/test/e2e/e2e_az_test.go
+++ b/test/e2e/e2e_az_test.go
@@ -28,7 +28,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -47,6 +46,8 @@ providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
   availabilityZone: "eu01-1"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
 secretRef:
   name: %s
   namespace: %s

--- a/test/e2e/e2e_keypair_test.go
+++ b/test/e2e/e2e_keypair_test.go
@@ -28,7 +28,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -46,6 +45,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   keypairName: "my-test-keypair"
 secretRef:
   name: %s

--- a/test/e2e/e2e_labels_test.go
+++ b/test/e2e/e2e_labels_test.go
@@ -33,7 +33,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -52,6 +51,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   labels:
     application: "web-server"
     team: "frontend"
@@ -76,6 +77,8 @@ metadata:
 providerSpec:
   machineType: "c1.4"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   labels:
     application: "database"
     team: "backend"
@@ -213,7 +216,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -231,6 +233,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   labels:
     test-propagation: "enabled"
     stack-component: "compute-worker"
@@ -411,7 +415,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -429,6 +432,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   # NO labels field - testing graceful handling of missing labels
 secretRef:
   name: %s

--- a/test/e2e/e2e_lifecycle_test.go
+++ b/test/e2e/e2e_lifecycle_test.go
@@ -28,7 +28,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -45,6 +44,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   labels:
     application: "web-server"
     team: "platform"
@@ -134,7 +135,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -151,6 +151,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   labels:
     application: "database"
     team: "backend"
@@ -230,7 +232,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -247,6 +248,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   labels:
     application: "monitoring"
     team: "sre"

--- a/test/e2e/e2e_metadata_test.go
+++ b/test/e2e/e2e_metadata_test.go
@@ -28,7 +28,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -46,6 +45,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   metadata:
     environment: "production"
     cost-center: "12345"

--- a/test/e2e/e2e_service_accounts_test.go
+++ b/test/e2e/e2e_service_accounts_test.go
@@ -28,7 +28,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -47,6 +46,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   serviceAccountMails:
     - "my-service@sa.stackit.cloud"
 secretRef:

--- a/test/e2e/e2e_userdata_test.go
+++ b/test/e2e/e2e_userdata_test.go
@@ -30,7 +30,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -48,6 +47,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -176,7 +177,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:

--- a/test/e2e/e2e_volumes_test.go
+++ b/test/e2e/e2e_volumes_test.go
@@ -30,7 +30,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -48,6 +47,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   bootVolume:
     size: 100
     performanceClass: "premium"
@@ -104,7 +105,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -122,6 +122,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   volumes:
     - "550e8400-e29b-41d4-a716-446655440000"
     - "660e8400-e29b-41d4-a716-446655440001"
@@ -178,7 +180,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -196,6 +197,8 @@ metadata:
 providerSpec:
   machineType: "c2i.2"
   imageId: "550e8400-e29b-41d4-a716-446655440000"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   bootVolume:
     size: 50
     performanceClass: "standard"
@@ -254,7 +257,6 @@ stringData:
   projectId: "12345678-1234-1234-1234-123456789012"
   serviceAccountKey: "{}"
   region: "eu01-1"
-  networkId: "770e8400-e29b-41d4-a716-446655440000"
   userData: |
     #cloud-config
     runcmd:
@@ -272,6 +274,8 @@ metadata:
   namespace: %s
 providerSpec:
   machineType: "c2i.2"
+  networking:
+    networkId: "770e8400-e29b-41d4-a716-446655440000"
   bootVolume:
     size: 80
     performanceClass: "premium"


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind technical-debt

**What this PR does / why we need it**:
Proving networkID from the Secret feels odd. We do not want that functionality. Other MCMs like GCP only provider userData aswell via Secret.

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
