### PR TITLE
wait for server to be ACTIVE

### DIFF
--- a/pkg/client/sdk.go
+++ b/pkg/client/sdk.go
@@ -206,12 +206,7 @@ func (c *SdkStackitClient) CreateServer(ctx context.Context, projectID, region s
 	}
 
 	// Convert SDK server to our Server type
-	server := &Server{
-		ID:     sdkServer.GetId(),
-		Name:   sdkServer.GetName(),
-		Status: sdkServer.GetStatus(),
-		Labels: convertLabelsFromSDK(sdkServer.Labels),
-	}
+	server := convertSDKServerToServer(sdkServer)
 
 	return server, nil
 }
@@ -228,12 +223,7 @@ func (c *SdkStackitClient) GetServer(ctx context.Context, projectID, region, ser
 	}
 
 	// Convert SDK server to our Server type
-	server := &Server{
-		ID:     sdkServer.GetId(),
-		Name:   sdkServer.GetName(),
-		Status: sdkServer.GetStatus(),
-		Labels: convertLabelsFromSDK(sdkServer.Labels),
-	}
+	server := convertSDKServerToServer(sdkServer)
 
 	return server, nil
 }
@@ -282,13 +272,7 @@ func (c *SdkStackitClient) ListServers(ctx context.Context, projectID, region st
 	if sdkResponse.Items != nil {
 		for i := range *sdkResponse.Items {
 			sdkServer := &(*sdkResponse.Items)[i]
-
-			server := &Server{
-				ID:     sdkServer.GetId(),
-				Name:   sdkServer.GetName(),
-				Status: sdkServer.GetStatus(),
-				Labels: convertLabelsFromSDK(sdkServer.Labels),
-			}
+			server := convertSDKServerToServer(sdkServer)
 			servers = append(servers, server)
 		}
 	}
@@ -355,6 +339,16 @@ func convertSDKNICtoNIC(nic *iaas.NIC) *NIC {
 		ID:               nic.GetId(),
 		NetworkID:        nic.GetNetworkId(),
 		AllowedAddresses: addresses,
+	}
+}
+
+func convertSDKServerToServer(sdkServer *iaas.Server) *Server {
+	return &Server{
+		ID:           sdkServer.GetId(),
+		Name:         sdkServer.GetName(),
+		Status:       sdkServer.GetStatus(),
+		ErrorMessage: sdkServer.GetErrorMessage(),
+		Labels:       convertLabelsFromSDK(sdkServer.Labels),
 	}
 }
 

--- a/pkg/client/stackit.go
+++ b/pkg/client/stackit.go
@@ -81,10 +81,11 @@ type AgentRequest struct {
 
 // Server represents a STACKIT server response
 type Server struct {
-	ID     string            `json:"id"`
-	Name   string            `json:"name"`
-	Status string            `json:"status"`
-	Labels map[string]string `json:"labels,omitempty"`
+	ID           string            `json:"id"`
+	Name         string            `json:"name"`
+	Status       string            `json:"status"`
+	ErrorMessage string            `json:"errorMessage,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
 }
 
 // NIC represents a STACKIT network interface

--- a/pkg/provider/create.go
+++ b/pkg/provider/create.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
@@ -13,6 +14,7 @@ import (
 	"github.com/stackitcloud/machine-controller-manager-provider-stackit/pkg/client"
 	api "github.com/stackitcloud/machine-controller-manager-provider-stackit/pkg/provider/apis"
 	"github.com/stackitcloud/machine-controller-manager-provider-stackit/pkg/provider/apis/validation"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
 
@@ -72,8 +74,19 @@ func (p *Provider) CreateMachine(ctx context.Context, req *driver.CreateMachineR
 		server, err = p.client.CreateServer(ctx, projectID, providerSpec.Region, p.createServerRequest(req, providerSpec))
 		if err != nil {
 			klog.Errorf("Failed to create server for machine %q: %v", req.Machine.Name, err)
+			if isResourceExhaustedError(err) {
+				return nil, status.Error(codes.ResourceExhausted, fmt.Sprintf("failed to create server: %v", err))
+			}
 			return nil, status.Error(codes.Unavailable, fmt.Sprintf("failed to create server: %v", err))
 		}
+	}
+
+	if err := p.WaitUntilServerRunning(ctx, projectID, providerSpec.Region, server.ID); err != nil {
+		klog.Errorf("Failed waiting for server %q to reach ACTIVE state: %v", req.Machine.Name, err)
+		if isResourceExhaustedError(err) {
+			return nil, status.Error(codes.ResourceExhausted, fmt.Sprintf("failed waiting for server to be ACTIVE: %v", err))
+		}
+		return nil, status.Error(codes.DeadlineExceeded, fmt.Sprintf("failed waiting for server to be ACTIVE: %v", err))
 	}
 
 	if err := p.patchNetworkInterface(ctx, projectID, server.ID, providerSpec); err != nil {
@@ -264,4 +277,24 @@ func (p *Provider) patchNetworkInterface(ctx context.Context, projectID, serverI
 	}
 
 	return nil
+}
+
+// WaitUntilServerRunning waits for the specified server to reach ACTIVE state
+// It polls the server status every 5 seconds with a maximum timeout of 5 minutes
+func (p *Provider) WaitUntilServerRunning(ctx context.Context, projectID, region, serverID string) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		server, err := p.client.GetServer(ctx, projectID, region, serverID)
+		if err != nil {
+			return false, err
+		}
+
+		klog.V(2).Infof("Waiting for server to reach ACTIVE state... (current status: %s)", server.Status)
+
+		if server.Status == "ACTIVE" {
+			klog.V(2).Infof("Server %q reached ACTIVE state", serverID)
+			return true, nil
+		}
+
+		return false, nil
+	})
 }

--- a/pkg/provider/helpers.go
+++ b/pkg/provider/helpers.go
@@ -58,3 +58,8 @@ func extractSecretCredentials(secretData map[string][]byte) (projectID, serviceA
 	serviceAccountKey = string(secretData[validation.StackitServiceAccountKey])
 	return projectID, serviceAccountKey
 }
+
+func isResourceExhaustedError(err error) bool {
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "no valid host") || strings.Contains(errMsg, "quota exceeded")
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	client2 "github.com/stackitcloud/machine-controller-manager-provider-stackit/pkg/client"
@@ -24,12 +25,17 @@ type Provider struct {
 	clientOnce          sync.Once             // Ensures client is initialized exactly once
 	clientErr           error                 // Stores initialization error if any
 	capturedCredentials string                // Service account key used for initialization (for defensive checks)
+	// intervals need to be configurable to speed up tests
+	pollingInterval time.Duration // Interval between polling attempts
+	pollingTimeout  time.Duration // Maximum time to wait during polling
 }
 
 // NewProvider returns an empty provider object
 func NewProvider(i spi.SessionProviderInterface) driver.Driver {
 	return &Provider{
-		SPI: i,
+		SPI:             i,
+		pollingInterval: 5 * time.Second,
+		pollingTimeout:  10 * time.Minute,
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Part of [STACKITSKE-6014](https://jira.schwarz/browse/STACKITSKE-6014).
We need to wait until the machine is ACTIVE in order to properly pass error messages to the customer. Otherwise ResourceExhausted errors will not reach the customer and the Machine will also be in CrashLoopBackoff even though it is just being created due to race conditions when patching the NICs.

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
