### PR TITLE
add custom domains for labels on iaas machines

### DIFF
--- a/pkg/provider/core.go
+++ b/pkg/provider/core.go
@@ -10,9 +10,7 @@ import (
 )
 
 const (
-	StackitProviderName      = "stackit"
-	StackitMachineLabel      = "kubernetes.io/machine"
-	StackitMachineClassLabel = "kubernetes.io/machineclass"
+	StackitProviderName = "stackit"
 )
 
 // GetVolumeIDs extracts volume IDs from PersistentVolume specs

--- a/pkg/provider/create.go
+++ b/pkg/provider/create.go
@@ -114,8 +114,8 @@ func (p *Provider) createServerRequest(req *driver.CreateMachineRequest, provide
 	}
 
 	// Add MCM-specific labels for server identification and orphan VM detection
-	labels[StackitMachineLabel] = req.Machine.Name
-	labels[StackitMachineClassLabel] = req.MachineClass.Name
+	labels[p.GetMachineLabelKey()] = req.Machine.Name
+	labels[p.GetMachineClassLabelKey()] = req.MachineClass.Name
 
 	// Create server request
 	createReq := &client.CreateServerRequest{
@@ -212,7 +212,7 @@ func (p *Provider) createServerRequest(req *driver.CreateMachineRequest, provide
 func (p *Provider) getServerByName(ctx context.Context, projectID, region, serverName string) (*client.Server, error) {
 	// Check if the server got already created
 	labelSelector := map[string]string{
-		StackitMachineLabel: serverName,
+		p.GetMachineLabelKey(): serverName,
 	}
 	servers, err := p.client.ListServers(ctx, projectID, region, labelSelector)
 	if err != nil {

--- a/pkg/provider/list.go
+++ b/pkg/provider/list.go
@@ -42,7 +42,7 @@ func (p *Provider) ListMachines(ctx context.Context, req *driver.ListMachinesReq
 
 	// Call STACKIT API to list all servers
 	labelSelector := map[string]string{
-		StackitMachineClassLabel: req.MachineClass.Name,
+		p.GetMachineClassLabelKey(): req.MachineClass.Name,
 	}
 	servers, err := p.client.ListServers(ctx, projectID, providerSpec.Region, labelSelector)
 	if err != nil {
@@ -51,7 +51,7 @@ func (p *Provider) ListMachines(ctx context.Context, req *driver.ListMachinesReq
 	}
 
 	// Filter servers by MachineClass label
-	// We use the "kubernetes.io/machineclass" label to identify which servers belong to this MachineClass
+	// We use the label to identify which servers belong to this MachineClass
 	machineList := make(map[string]string)
 	for _, server := range servers {
 		// Generate ProviderID in format: stackit://<projectId>/<serverId>
@@ -59,7 +59,7 @@ func (p *Provider) ListMachines(ctx context.Context, req *driver.ListMachinesReq
 
 		// Get machine name from labels (fallback to server name if not found)
 		machineName := server.Name
-		if machineLabel, ok := server.Labels[StackitMachineLabel]; ok {
+		if machineLabel, ok := server.Labels[p.GetMachineLabelKey()]; ok {
 			machineName = machineLabel
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
We want to distinguish between different gardener installations on a server level. With the customDomainLabel one installation can have "ske.stackit.cloud/machine: servername" whereas one could have "gardener.cloud/machine: servername".

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
