### PR TITLE
Release doc

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -23,6 +23,41 @@ For major version changes, the configuration typically needs to be adapted to ac
 
 Both major and minor releases are created from the main branch. Patch releases are created from a release branch that is based on a minor version release.
 
+### 🚑 Hotfixes
+
+A Hotfix is required when a critical bug or security vulnerability is discovered in a stable version that is currently in production, but the main branch has already moved forward with breaking changes or features not yet ready for release.
+
+We follow a "Fix-First-in-Main" policy. All fixes must be merged into the main branch before being cherry-picked into a specific release branch.
+
+For example:
+
+```mermaid
+gitGraph:
+    commit id: "v1.0.0" tag: "v1.0.0"
+    branch release-v1.0
+    checkout main
+    commit id: "Feature A"
+    commit id: "Breaking Change" tag: "v2.0.0-beta"
+    commit id: "Critical Bugfix"
+    commit id: "Feature B"
+    checkout release-v1.0
+    commit id: "cherry-pick Bugfix" tag: "v1.0.1"
+```
+
+> In the example above, the "Critical Bugfix" cannot be released via the main branch because main contains a "Breaking Change" that isn't ready for general availability. By using a release branch (release-v1.0), we can ship the fix as a patch (v1.0.1) immediately.
+
+1. Create a Pull Request (PR) targeting the main branch. Once reviewed and merged, identify the PR number.
+2. If a branch for your specific minor version (e.g., release-v1.x) doesn't exist yet, create it from the last known stable tag:
+   ```bash
+   git fetch --all --tags
+   git checkout -b release-vx.y vx.y.0
+   git push -u origin release-vx.y
+   ```
+3. Use our helper script to pull the specific PR(s) into your release branch. This ensures metadata and credits remain intact.
+4. Once the cherry-pick PR has been reviewed, approved, and merged, you can promote the changes by creating a new patch release of machine-controller-manager-provider-stackit.
+   For this, publish the draft release on the `release-vx.y` branch for the next patch version (`vx.y.z`) (see [Publishing a Release](#-publishing-a-release)).
+
+
 To make sure we release with the correct version bump, every breaking PR needs to be labeled with the breaking label (e.g., via /label breaking) so that it is automatically categorized correctly when generating release notes.
 
 ## 🔖 Publishing a Release

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,11 +13,11 @@ This document outlines the standard procedure for creating new releases of the S
 
 ## General Information
 
-- **Branching Strategy:** All major and minor releases are created from `main` branches. Patch releases are created from  `release-v*` branches (see [Patch Release (Hotfix)](#hotfixes) for more details).
+- **Branching Strategy:** All major and minor releases are created from `main` branches. Patch releases are created from  `release-v*` branches (see [Patch Release (Hotfix)](#patch-version-hotfix) for more details).
 - **Versioning:** Versioning follows official [SemVer 2.0](https://semver.org/)
 - **CI/CD System:** All release and image builds are managed by our **Prow CI** infrastructure.
 
-### Hotfixes
+### Patch Version (Hotfix)
 
 A Hotfix is required when a critical bug or security vulnerability is discovered in a stable version that is currently in use, but the main branch has already moved forward with breaking changes or features.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,6 +4,7 @@
 
 - [Overview](#overview)
 - [General Information](#general-information)
+- [Patch Version (Hotfix)](#patch-version-hotfix)
 - [Automated Release Process (Primary Method)](#automated-release-process-primary-method)
 - [Manual Release Process (Fallback Method)](#manual-release-process-fallback-method)
 
@@ -17,7 +18,7 @@ This document outlines the standard procedure for creating new releases of the S
 - **Versioning:** Versioning follows official [SemVer 2.0](https://semver.org/)
 - **CI/CD System:** All release and image builds are managed by our **Prow CI** infrastructure.
 
-### Patch Version (Hotfix)
+## Patch Version (Hotfix)
 
 A Hotfix is required when a critical bug or security vulnerability is discovered in a stable version that is currently in use, but the main branch has already moved forward with breaking changes or features.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -34,6 +34,33 @@ In case of machine-controller-manager-provider-stackit, we use the following typ
    - a critical change needs to be rolled out without other major/minor changes
    - it can be promoted automatically
 
+Both major and minor releases are created from the main branch. Patch releases are created from a release branch that is based on a minor version release.
+
+To make sure we release with the correct version bump, every breaking PR needs to be labeled with the breaking label (e.g., via /label breaking) so that it is automatically categorized correctly when generating release notes.
+
+### 🚀 Basic Promotion (Minor Releases)
+
+> [!NOTE]
+> We are now reconciling in maintenance only.
+> There is no more reconciliation every hour!
+
+The basic promotion workflow is quite simple:
+
+1. Create a PR to merge your changes on [:octocat: machine-controller-manager-provider-stackit](https://github.com/stackitcloud/machine-controller-manager-provider-stackit) into the `main` branch.
+2. Once you have verified the changes on dev [TODO: if the dev is okay to write here], you can promote the changes by creating a new minor release of ske-base.
+   For this, publish the draft release on the `main` branch for the next minor version (`vx.y.0`) (see [Publishing a Release](#-publishing-a-release)).
+   Review the release notes and make sure, the changes since the last release don't contain any breaking changes.
+
+### ⚠️ Promotion with Adaptions (Major Releases)
+
+When promoting major releases of machine-controller-manager-provider-stackit, the promotion workflow is the following:
+
+1. Create a PR to merge your changes on [:octocat: machine-controller-manager-provider-stackit](https://github.com/stackitcloud/machine-controller-manager-provider-stackit) into the `main` branch. Add `/label breaking` to your PR description.
+2. Once you have verified the changes, you can promote the changes by creating a new major release of ske-base.
+   For this, publish the draft release on the `main` branch for the next major version (`vx.0.0`) (see [Publishing a Release](#-publishing-a-release)).
+
+TODO: should we add hofixes part?
+
 ## General Information
 
 - **Versioning:** Versioning follows official [SemVer 2.0](https://semver.org/)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,7 +2,37 @@
 
 ## Overview
 
-This document outlines the standard procedure for creating new releases of the STACKIT machine-controller-manager.
+To push new changes to the release, start with a PR to the main branch. Make sure to follow the PR template.
+
+### 🏷️ Versioning
+
+When releasing machine-controller-manager-provider-stackit, we follow semantic versioning (see https://semver.org/).
+
+In short:
+- versions have the `vX.Y.Z` pattern, with `X` being the major version, `Y` being the minor version, and `Z` being the patch version
+- ⚠️ a new major version (`vX.0.0`, `X` is bumped)
+   - brings new features/refactorings/etc.
+   - implies breaking changes to consumers of the package (i.e., incompatible with the last major)
+- 🚀 a new minor version (`vX.Y.0`, `Y` is bumped)
+   - brings new features/refactorings/etc.
+   - does not imply breaking changes (i.e., compatible with the last minor)
+- 🚑 a new patch version (`vX.Y.Z`, `Z` is bumped)
+   - brings bug fixes without new features/refactorings/etc.
+   - does not imply breaking changes (i.e., compatible with the last patch)
+
+For major version changes, consumers typically need to adapt their usage of the package to the breaking changes before they can successfully upgrade. For minor and patch version changes, no adaptions are needed.
+
+In case of machine-controller-manager-provider-stackit, we use the following types of releases:
+
+- ⚠️ a new major version is released if
+   - manual steps are required after rolling out the change TODO: ask if it is required
+   - Gardener Upgrades
+- 🚀 a new minor version is released if
+   - it doesn't come with a known impact on customers
+   - it can be promoted automatically
+- 🚑 a new patch version is released if
+   - a critical change needs to be rolled out without other major/minor changes
+   - it can be promoted automatically
 
 ## General Information
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,15 +13,13 @@ This document outlines the standard procedure for creating new releases of the S
 
 ## General Information
 
-When releasing machine-controller-manager-provider-stackit, we follow semantic versioning (see https://semver.org/).
-
-For major version changes, the configuration typically needs to be adapted to accommodate breaking changes before successfully upgrading. For minor and patch updates, no configuration adjustments are required.
-
-Both major and minor releases are created from the main branch. Patch releases are created from a release branch that is based on a minor version release.
+- **Branching Strategy:** All major and minor releases are created from `main` branches. Patch releases are created from  `release-v*` branches (see [Patch Release (Hotfix)](#hotfixes) for more details).
+- **Versioning:** Versioning follows official [SemVer 2.0](https://semver.org/)
+- **CI/CD System:** All release and image builds are managed by our **Prow CI** infrastructure.
 
 ### Hotfixes
 
-A Hotfix is required when a critical bug or security vulnerability is discovered in a stable version that is currently in production, but the main branch has already moved forward with breaking changes or features not yet ready for release.
+A Hotfix is required when a critical bug or security vulnerability is discovered in a stable version that is currently in use, but the main branch has already moved forward with breaking changes or features.
 
 We follow a "Fix-First-in-Main" policy. All fixes must be merged into the main branch before being cherry-picked into a specific release branch.
 
@@ -33,39 +31,35 @@ gitGraph:
     branch release-v1.0
     checkout main
     commit id: "Feature A"
-    commit id: "Breaking Change" tag: "v2.0.0-beta"
-    commit id: "Critical Bugfix"
-    commit id: "Feature B"
+    commit id: "Breaking Change"
+    commit id: "Bugfix"
     checkout release-v1.0
-    commit id: "cherry-pick Bugfix" tag: "v1.0.1"
+    cherry-pick id: "Bugfix"
+    commit id: "v1.0.1" tag: "v1.0.1"
 ```
 
-> In the example above, the "Critical Bugfix" cannot be released via the main branch because main contains a "Breaking Change" that isn't ready for general availability. By using a release branch (release-v1.0), we can ship the fix as a patch (v1.0.1) immediately.
+> As shown in the example, the `Critical Bugfix` cannot be released directly from main because that branch already contains unreleased work (like `Feature A` or the `Breaking Change`) that shouldn't be shipped alongside a patch. Isolating the fix on `release-v1.0` ensures we release only the `Critical Bugfix` in the patch release (`v1.0.1`).
 
-1. Create a Pull Request (PR) targeting the main branch. Once reviewed and merged, identify the PR number.
-2. If a branch for your specific minor version (e.g., release-v1.x) doesn't exist yet, create it from the last known stable tag:
+1. Create a Pull Request with the bug fix targeting the main branch.
+2. Review and merge the `main` branch Pull Request.
+3. If a branch for your specific minor version (e.g., `release-v1.0`) doesn't exist yet, create it from the corresponding tag:
    ```bash
    git fetch --all --tags
    git checkout -b release-vx.y vx.y.0
    git push -u origin release-vx.y
    ```
-3. Use `/cherry-pick release-vx.y` command in the PR with the changes. The prow will open the cherry-pick PR automatically.
-4. Once the cherry-pick PR has been reviewed, approved, and merged, you can promote the changes by creating a new patch release of machine-controller-manager-provider-stackit.
-   For this, publish the draft release on the `release-vx.y` branch for the next patch version (`vx.y.z`) (see [Publishing a Release](#-publishing-a-release)).
+4. Use `/cherry-pick release-vx.y` command in the `main` branch Pull Request. The prow will open the cherry-pick Pull Request against `release-vx.y` branch automatically.
+5. Once the cherry-pick PR has been reviewed, approved, and merged, you can promote the changes by creating a new patch release of machine-controller-manager-provider-stackit.
+   For this, publish the draft release on the `release-vx.y` branch for the next patch version (`vx.y.z`) (see [Automated Release Process (Primary Method)](#automated-release-process-primary-method)).
 
 ## Automated Release Process (Primary Method)
 
-When changes are merged into `main` or a `release-v*` branch, the `release-tool` creates a draft release to preview the upcoming updates.
-The tool automatically determines the appropriate version tag based on the target branch and the labels of the merged Pull Requests:
+The primary release method is automated using a tool called `release-tool`. This process is designed to be straightforward and require minimal manual intervention.
 
-To publish a release, follow these steps:
+1. **Draft Creation:** On every successful merge (post-submit) to the `main` branch and `release-v*` branchs, a Prow job automatically runs the `release-tool`. This tool creates a new draft release on GitHub or updates the existing one with a changelog generated from recent commits.
+2. **Publishing the Release:** When the draft is ready, navigate to the repository's "Releases" page on GitHub. Locate the draft, review the changelog, replace the placeholder with your GitHub handle and publish it by clicking the "Publish release" button.
 
-1. Open the repository's releases page.
-2. Navigate to the corresponding draft release (minor/major for `main`, patch for `release-v*`).
-3. Review to-be-released changes by checking the release notes.
-4. Edit the release by pressing the pen icon.
-5. Change `REPLACE_ME` with your github username.
-6. Press the "Publish release" button.
+Publishing the release automatically creates the corresponding Git tag (e.g., `v1.3.1`), which triggers a separate Prow job to build the final container images and attach them to the GitHub release.
 
 ## Manual Release Process (Fallback Method)
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -61,19 +61,20 @@ When promoting major releases of machine-controller-manager-provider-stackit, th
 
 TODO: should we add hofixes part?
 
-## General Information
 
-- **Versioning:** Versioning follows official [SemVer 2.0](https://semver.org/)
-- **CI/CD System:** All release and image builds are managed by our **Prow CI** infrastructure.
+## 🔖 Publishing a Release
 
-## Automated Release Process (Primary Method)
+When changes are merged into `main` or a `release-v*` branch, the [release-tool](https://github.com/stackitcloud/ske-ci-infra/blob/main/docs/release-tool.md) generates a draft release for the next release on the branch as a preview of the to-be-released changes.
+It automatically chooses the correct tag. I.e., it bumps the major version if there are unreleased breaking changes on `main`, or otherwise bumps the minor version for `main` or bumps the patch version for `release-v*` branches.
 
-The primary release method is automated using a tool called `release-tool`. This process is designed to be straightforward and require minimal manual intervention.
+To publish a release, follow these steps:
 
-1. **Draft Creation:** On every successful merge (post-submit) to the `main` branch, a Prow job automatically runs the `release-tool`. This tool creates a new draft release on GitHub or updates the existing one with a changelog generated from recent commits.
-2. **Publishing the Release:** When the draft is ready, navigate to the repository's "Releases" page on GitHub. Locate the draft, review the changelog, replace the placeholder with your GitHub handle and publish it by clicking the "Publish release" button.
-
-Publishing the release automatically creates the corresponding Git tag (e.g., `v1.3.1`), which triggers a separate Prow job to build the final container images and attach them to the GitHub release.
+1. Open the repository's releases page.
+2. Navigate to the corresponding draft release (minor/major for `main`, patch for `release-v*`).
+3. Review to-be-released changes by checking the release notes.
+4. Edit the release by pressing the pen icon.
+5. Change `REPLACE_ME` with your github username.
+6. Press the "Publish release" button.
 
 ## Manual Release Process (Fallback Method)
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,14 +2,13 @@
 
 ## Overview
 
-To push new changes to the release, start with a PR to the main branch. Make sure to follow the PR template.
+This document outlines the standard procedure for creating new releases of the STACKIT machine-controller-manager.
 
 ### 🏷️ Versioning
 
 When releasing machine-controller-manager-provider-stackit, we follow semantic versioning (see https://semver.org/).
 
 In short:
-- versions have the `vX.Y.Z` pattern, with `X` being the major version, `Y` being the minor version, and `Z` being the patch version
 - ⚠️ a new major version (`vX.0.0`, `X` is bumped)
    - brings new features/refactorings/etc.
    - implies breaking changes to consumers of the package (i.e., incompatible with the last major)
@@ -20,52 +19,16 @@ In short:
    - brings bug fixes without new features/refactorings/etc.
    - does not imply breaking changes (i.e., compatible with the last patch)
 
-For major version changes, consumers typically need to adapt their usage of the package to the breaking changes before they can successfully upgrade. For minor and patch version changes, no adaptions are needed.
-
-In case of machine-controller-manager-provider-stackit, we use the following types of releases:
-
-- ⚠️ a new major version is released if
-   - manual steps are required after rolling out the change TODO: ask if it is required
-   - Gardener Upgrades
-- 🚀 a new minor version is released if
-   - it doesn't come with a known impact on customers
-   - it can be promoted automatically
-- 🚑 a new patch version is released if
-   - a critical change needs to be rolled out without other major/minor changes
-   - it can be promoted automatically
+For major version changes, the configuration typically needs to be adapted to accommodate breaking changes before successfully upgrading. For minor and patch updates, no configuration adjustments are required.
 
 Both major and minor releases are created from the main branch. Patch releases are created from a release branch that is based on a minor version release.
 
 To make sure we release with the correct version bump, every breaking PR needs to be labeled with the breaking label (e.g., via /label breaking) so that it is automatically categorized correctly when generating release notes.
 
-### 🚀 Basic Promotion (Minor Releases)
-
-> [!NOTE]
-> We are now reconciling in maintenance only.
-> There is no more reconciliation every hour!
-
-The basic promotion workflow is quite simple:
-
-1. Create a PR to merge your changes on [:octocat: machine-controller-manager-provider-stackit](https://github.com/stackitcloud/machine-controller-manager-provider-stackit) into the `main` branch.
-2. Once you have verified the changes on dev [TODO: if the dev is okay to write here], you can promote the changes by creating a new minor release of ske-base.
-   For this, publish the draft release on the `main` branch for the next minor version (`vx.y.0`) (see [Publishing a Release](#-publishing-a-release)).
-   Review the release notes and make sure, the changes since the last release don't contain any breaking changes.
-
-### ⚠️ Promotion with Adaptions (Major Releases)
-
-When promoting major releases of machine-controller-manager-provider-stackit, the promotion workflow is the following:
-
-1. Create a PR to merge your changes on [:octocat: machine-controller-manager-provider-stackit](https://github.com/stackitcloud/machine-controller-manager-provider-stackit) into the `main` branch. Add `/label breaking` to your PR description.
-2. Once you have verified the changes, you can promote the changes by creating a new major release of ske-base.
-   For this, publish the draft release on the `main` branch for the next major version (`vx.0.0`) (see [Publishing a Release](#-publishing-a-release)).
-
-TODO: should we add hofixes part?
-
-
 ## 🔖 Publishing a Release
 
-When changes are merged into `main` or a `release-v*` branch, the [release-tool](https://github.com/stackitcloud/ske-ci-infra/blob/main/docs/release-tool.md) generates a draft release for the next release on the branch as a preview of the to-be-released changes.
-It automatically chooses the correct tag. I.e., it bumps the major version if there are unreleased breaking changes on `main`, or otherwise bumps the minor version for `main` or bumps the patch version for `release-v*` branches.
+When changes are merged into `main` or a `release-v*` branch, the `release-tool` creates a draft release to preview the upcoming updates.
+The tool automatically determines the appropriate version tag based on the target branch and the labels of the merged Pull Requests:
 
 To publish a release, follow these steps:
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,10 +1,17 @@
 # Release Procedure
 
+# Table of Contents
+
+- [Overview](#overview)
+- [General Information](#general-information)
+- [Automated Release Process (Primary Method)](#automated-release-process-primary-method)
+- [Manual Release Process (Fallback Method)](#manual-release-process-fallback-method)
+
 ## Overview
 
 This document outlines the standard procedure for creating new releases of the STACKIT machine-controller-manager.
 
-### Versioning
+## General Information
 
 When releasing machine-controller-manager-provider-stackit, we follow semantic versioning (see https://semver.org/).
 
@@ -42,11 +49,11 @@ gitGraph:
    git checkout -b release-vx.y vx.y.0
    git push -u origin release-vx.y
    ```
-3. Use `/cherry-pick release-vx.y` command in the PR with the changes. The ronovate will open the cherry-pick PR automatically.
+3. Use `/cherry-pick release-vx.y` command in the PR with the changes. The prow will open the cherry-pick PR automatically.
 4. Once the cherry-pick PR has been reviewed, approved, and merged, you can promote the changes by creating a new patch release of machine-controller-manager-provider-stackit.
    For this, publish the draft release on the `release-vx.y` branch for the next patch version (`vx.y.z`) (see [Publishing a Release](#-publishing-a-release)).
 
-### Publishing a Release
+## Automated Release Process (Primary Method)
 
 When changes are merged into `main` or a `release-v*` branch, the `release-tool` creates a draft release to preview the upcoming updates.
 The tool automatically determines the appropriate version tag based on the target branch and the labels of the merged Pull Requests:
@@ -60,7 +67,7 @@ To publish a release, follow these steps:
 5. Change `REPLACE_ME` with your github username.
 6. Press the "Publish release" button.
 
-### Manual Release Process (Fallback Method)
+## Manual Release Process (Fallback Method)
 
 If the `release-tool` or its associated Prow job fails, use the GitHub web UI to create and publish a release:
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,26 +4,15 @@
 
 This document outlines the standard procedure for creating new releases of the STACKIT machine-controller-manager.
 
-### 🏷️ Versioning
+### Versioning
 
 When releasing machine-controller-manager-provider-stackit, we follow semantic versioning (see https://semver.org/).
-
-In short:
-- ⚠️ a new major version (`vX.0.0`, `X` is bumped)
-   - brings new features/refactorings/etc.
-   - implies breaking changes to consumers of the package (i.e., incompatible with the last major)
-- 🚀 a new minor version (`vX.Y.0`, `Y` is bumped)
-   - brings new features/refactorings/etc.
-   - does not imply breaking changes (i.e., compatible with the last minor)
-- 🚑 a new patch version (`vX.Y.Z`, `Z` is bumped)
-   - brings bug fixes without new features/refactorings/etc.
-   - does not imply breaking changes (i.e., compatible with the last patch)
 
 For major version changes, the configuration typically needs to be adapted to accommodate breaking changes before successfully upgrading. For minor and patch updates, no configuration adjustments are required.
 
 Both major and minor releases are created from the main branch. Patch releases are created from a release branch that is based on a minor version release.
 
-### 🚑 Hotfixes
+### Hotfixes
 
 A Hotfix is required when a critical bug or security vulnerability is discovered in a stable version that is currently in production, but the main branch has already moved forward with breaking changes or features not yet ready for release.
 
@@ -53,14 +42,11 @@ gitGraph:
    git checkout -b release-vx.y vx.y.0
    git push -u origin release-vx.y
    ```
-3. Use our helper script to pull the specific PR(s) into your release branch. This ensures metadata and credits remain intact.
+3. Use `/cherry-pick release-vx.y` command in the PR with the changes. The ronovate will open the cherry-pick PR automatically.
 4. Once the cherry-pick PR has been reviewed, approved, and merged, you can promote the changes by creating a new patch release of machine-controller-manager-provider-stackit.
    For this, publish the draft release on the `release-vx.y` branch for the next patch version (`vx.y.z`) (see [Publishing a Release](#-publishing-a-release)).
 
-
-To make sure we release with the correct version bump, every breaking PR needs to be labeled with the breaking label (e.g., via /label breaking) so that it is automatically categorized correctly when generating release notes.
-
-## 🔖 Publishing a Release
+### Publishing a Release
 
 When changes are merged into `main` or a `release-v*` branch, the `release-tool` creates a draft release to preview the upcoming updates.
 The tool automatically determines the appropriate version tag based on the target branch and the labels of the merged Pull Requests:
@@ -74,7 +60,7 @@ To publish a release, follow these steps:
 5. Change `REPLACE_ME` with your github username.
 6. Press the "Publish release" button.
 
-## Manual Release Process (Fallback Method)
+### Manual Release Process (Fallback Method)
 
 If the `release-tool` or its associated Prow job fails, use the GitHub web UI to create and publish a release:
 


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement
/kind documentation

**What this PR does / why we need it**:

This PR adds documentation for the release process for the machine-controller-manager-provider-stackit. Explaining, major, minor and patch releases and using our release tool.

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
