### PR TITLE
add the ability to use the metro zone

### DIFF
--- a/pkg/provider/apis/validation/validation.go
+++ b/pkg/provider/apis/validation/validation.go
@@ -35,8 +35,8 @@ var machineTypeRegex = regexp.MustCompile(`^[a-z]+\d+[a-z]*\.\d+[a-z]*(\.[a-z]+\
 var regionRegex = regexp.MustCompile(`^[a-z0-9]+$`)
 
 // availabilityZoneRegex is a regex pattern for validating STACKIT availability zone format
-// Pattern: lowercase letters/digits followed by digits, dash, then digit(s) (e.g., eu01-1, eu01-2)
-var availabilityZoneRegex = regexp.MustCompile(`^[a-z0-9]+-\d+$`)
+// Pattern: lowercase letters/digits followed by dash, then digits or letter 'm' (e.g., eu01-1, eu01-2, eu01-m)
+var availabilityZoneRegex = regexp.MustCompile(`^[a-z0-9]+-(?:\d+|m)$`)
 
 // labelKeyRegex validates Kubernetes label keys (must start/end with alphanumeric, can contain -, _, ., /)
 // Maximum length: 63 characters

--- a/pkg/provider/apis/validation/validation_fields_test.go
+++ b/pkg/provider/apis/validation/validation_fields_test.go
@@ -129,11 +129,30 @@ var _ = Describe("ValidateProviderSpecNSecret", func() {
 				"eu01-2",
 				"eu02-1",
 				"eu02-4",
+				"eu01-m",
+				"eu02-m",
 			}
 			for _, az := range testCases {
 				providerSpec.AvailabilityZone = az
 				errors := ValidateProviderSpecNSecret(providerSpec, secret)
 				Expect(errors).To(BeEmpty(), "AvailabilityZone %q should be valid", az)
+			}
+		})
+
+		It("should fail with invalid availabilityZone formats", func() {
+			invalidCases := []string{
+				"eu01-a",  // letter other than 'm'
+				"eu01-m1", // 'm' followed by digit
+				"eu01",    // missing dash and suffix
+				"eu01-",   // missing suffix
+				"-1",      // missing prefix
+				"eu01-mm", // multiple letters
+			}
+			for _, az := range invalidCases {
+				providerSpec.AvailabilityZone = az
+				errors := ValidateProviderSpecNSecret(providerSpec, secret)
+				Expect(errors).NotTo(BeEmpty(), "AvailabilityZone %q should be invalid", az)
+				Expect(errors[0].Error()).To(ContainSubstring("invalid format"))
 			}
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Currently zones do need digits after the dash. That prevents using the metro zone.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
/hold not tested yet
