### PR TITLE
Add metrics for API calls

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -6,13 +6,19 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/app/options"
 	_ "github.com/gardener/machine-controller-manager/pkg/util/reflector/prometheus" // for reflector metric registration
 	_ "github.com/gardener/machine-controller-manager/pkg/util/workqueue/prometheus" // for workqueue metric registration
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/pflag"
+	"github.com/stackitcloud/machine-controller-manager-provider-stackit/pkg/metrics"
 	cp "github.com/stackitcloud/machine-controller-manager-provider-stackit/pkg/provider"
 	"github.com/stackitcloud/machine-controller-manager-provider-stackit/pkg/spi"
 	"k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 )
+
+func init() {
+	prometheus.MustRegister(metrics.NewExporter())
+}
 
 func main() {
 	s := options.NewMCServer()

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ go 1.26.2
 
 require (
 	github.com/gardener/machine-controller-manager v0.62.1
+	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stackitcloud/stackit-sdk-go/core v0.26.0
 	github.com/stackitcloud/stackit-sdk-go/services/iaas v1.14.1
@@ -33,17 +36,15 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect

--- a/pkg/client/sdk.go
+++ b/pkg/client/sdk.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/stackitcloud/machine-controller-manager-provider-stackit/pkg/metrics"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
@@ -73,6 +74,8 @@ func createIAASClient(serviceAccountKey string) (*iaas.APIClient, error) {
 	if tokenEndpoint != "" {
 		opts = append(opts, config.WithTokenEndpoint(tokenEndpoint))
 	}
+
+	opts = append(opts, config.WithHTTPClient(metrics.NewHTTPClient("machine-controller-manager-provider-stackit")))
 
 	iaasClient, err := iaas.NewAPIClient(opts...)
 	if err != nil {

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -18,6 +19,9 @@ func NewHTTPClient(componentName string) *http.Client {
 }
 
 func WrapHTTPClient(client *http.Client, componentName string) *http.Client {
+	if client == nil {
+		return nil
+	}
 	wrappedClient := *client
 
 	baseTransport := client.Transport
@@ -49,9 +53,15 @@ func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Resp
 		statusCode = strconv.Itoa(response.StatusCode)
 	}
 
+	// request.Host is optional so we can fallback to request.URL.Host (if available)
+	host := request.Host
+	if host == "" && request.URL != nil {
+		host = request.URL.Host
+	}
+
 	labels := prometheus.Labels{
 		componentLabel: rt.componentName,
-		hostLabel:      request.Host,
+		hostLabel:      host,
 		methodLabel:    request.Method,
 		operationLabel: getSDKOperationName(),
 		codeLabel:      statusCode,
@@ -105,7 +115,8 @@ func getSDKOperationName() string {
 			}
 
 			// Skip Private functions
-			if !unicode.IsUpper(rune(funcName[0])) {
+			r, _ := utf8.DecodeRuneInString(funcName)
+			if !unicode.IsUpper(r) {
 				continue
 			}
 

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -1,0 +1,117 @@
+package metrics
+
+import (
+	"net/http"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const UnknownOperation = "UnknownOperation"
+
+func NewHTTPClient(componentName string) *http.Client {
+	return WrapHTTPClient(http.DefaultClient, componentName)
+}
+
+func WrapHTTPClient(client *http.Client, componentName string) *http.Client {
+	wrappedClient := *client
+
+	baseTransport := client.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+
+	// Chain your instrumented round tripper
+	wrappedClient.Transport = &InstrumentedRoundTripper{
+		base:          baseTransport,
+		componentName: componentName,
+	}
+
+	return &wrappedClient
+}
+
+type InstrumentedRoundTripper struct {
+	base          http.RoundTripper
+	componentName string
+}
+
+func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	startTime := time.Now()
+	response, err := rt.base.RoundTrip(request)
+	duration := time.Since(startTime)
+
+	statusCode := "network_error"
+	if response != nil {
+		statusCode = strconv.Itoa(response.StatusCode)
+	}
+
+	labels := prometheus.Labels{
+		componentLabel: rt.componentName,
+		hostLabel:      request.Host,
+		methodLabel:    request.Method,
+		operationLabel: getSDKOperationName(),
+		codeLabel:      statusCode,
+	}
+
+	HTTPRequestDurationHistogram.With(labels).Observe(duration.Seconds())
+	HTTPRequestCount.With(labels).Inc()
+
+	isHTTPError := response != nil && response.StatusCode >= 400
+	isNetworkError := err != nil
+
+	if isHTTPError || isNetworkError {
+		HTTPErrorCount.With(labels).Inc()
+	}
+
+	return response, err
+}
+
+// getSDKOperationName returns the name of the STACKIT SDK function. To do this the function gets the last 10 callers and checks
+// for functions from the stackitcloud/stackit-sdk-go. It fall back to UnknownOperation if no function was found.
+func getSDKOperationName() string {
+	pc := make([]uintptr, 10)
+
+	// Skip 3 because the first 3 are always Callers, getSDKOperationName, RoundTrip.
+	n := runtime.Callers(3, pc)
+	if n == 0 {
+		return UnknownOperation
+	}
+
+	frames := runtime.CallersFrames(pc[:n])
+	moreFrames := true
+	for moreFrames {
+		var frame runtime.Frame
+		frame, moreFrames = frames.Next()
+
+		if !strings.Contains(frame.Function, "stackitcloud/stackit-sdk-go") {
+			continue
+		}
+
+		parts := strings.Split(frame.Function, ".")
+		if len(parts) > 0 {
+			funcName := parts[len(parts)-1]
+
+			// Skip function names with 0 len
+			// Skip Execute, because there is a function with more detailed name
+			// Skip RoundTrip, because this only the RoundTrip for the AuthFlow
+			if funcName == "" ||
+				funcName == "Execute" ||
+				funcName == "RoundTrip" {
+				continue
+			}
+
+			// Skip Private functions
+			if !unicode.IsUpper(rune(funcName[0])) {
+				continue
+			}
+
+			return strings.TrimSuffix(funcName, "Execute")
+		}
+	}
+
+	return UnknownOperation
+}

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -1,0 +1,216 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	sdkconfig "github.com/stackitcloud/stackit-sdk-go/core/config"
+	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
+)
+
+var _ = Describe("Metrics", func() {
+	Describe("getSDKOperationName", func() {
+		var (
+			server     *httptest.Server
+			host       string
+			component  = "test"
+			iaasClient *iaas.APIClient
+		)
+
+		BeforeEach(func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			url, err := url.Parse(server.URL)
+			Expect(err).NotTo(HaveOccurred())
+			host = url.Host
+
+			HTTPRequestCount.Reset()
+			HTTPErrorCount.Reset()
+			HTTPRequestDurationHistogram.Reset()
+
+			iaasClient, err = iaas.NewAPIClient(
+				sdkconfig.WithHTTPClient(NewHTTPClient(component)),
+				sdkconfig.WithEndpoint(server.URL),
+				sdkconfig.WithoutAuthentication(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		It("should return DeleteVolume as operation", func() {
+			err := iaasClient.DefaultAPI.DeleteVolume(context.TODO(), uuid.New().String(), "", uuid.New().String()).Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			labels := prometheus.Labels{
+				hostLabel:      host,
+				componentLabel: component,
+				methodLabel:    "DELETE",
+				operationLabel: "DeleteVolume",
+				codeLabel:      "200",
+			}
+
+			Expect(testutil.ToFloat64(HTTPRequestCount.With(labels))).To(Equal(float64(1)))
+		})
+
+		It("should return DeleteServer as operation", func() {
+			err := iaasClient.DefaultAPI.DeleteServer(context.TODO(), uuid.New().String(), "", uuid.New().String()).Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			labels := prometheus.Labels{
+				hostLabel:      host,
+				componentLabel: component,
+				methodLabel:    "DELETE",
+				operationLabel: "DeleteServer",
+				codeLabel:      "200",
+			}
+
+			Expect(testutil.ToFloat64(HTTPRequestCount.With(labels))).To(Equal(float64(1)))
+		})
+	})
+
+	Describe("InstrumentedRoundTripper", func() {
+		var (
+			server     *httptest.Server
+			httpClient *http.Client
+			host       string
+			component  = "test"
+		)
+
+		BeforeEach(func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/404":
+					w.WriteHeader(http.StatusNotFound)
+				case "/500":
+					w.WriteHeader(http.StatusInternalServerError)
+				case "/400":
+					w.WriteHeader(http.StatusBadRequest)
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			url, err := url.Parse(server.URL)
+			Expect(err).NotTo(HaveOccurred())
+			host = url.Host
+			httpClient = NewHTTPClient(component)
+
+			HTTPRequestCount.Reset()
+			HTTPErrorCount.Reset()
+			HTTPRequestDurationHistogram.Reset()
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		It("increments HTTPRequestCount for responses", func() {
+			labels := prometheus.Labels{
+				hostLabel:      host,
+				componentLabel: component,
+				methodLabel:    "GET",
+				operationLabel: UnknownOperation,
+				codeLabel:      "200",
+			}
+
+			response, err := httpClient.Get(server.URL + "/request-count-test")
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+
+			Expect(testutil.ToFloat64(HTTPRequestCount.With(labels))).To(Equal(float64(1)))
+		})
+
+		It("records HTTPRequestDurationHistogram observations for responses", func() {
+			labels := prometheus.Labels{
+				hostLabel:      host,
+				componentLabel: component,
+				methodLabel:    "GET",
+				operationLabel: UnknownOperation,
+				codeLabel:      "200",
+			}
+
+			response, err := httpClient.Get(server.URL + "/request-duration-test")
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+
+			Expect(histogramSampleCount(HTTPRequestDurationHistogram.With(labels))).To(Equal(uint64(1)))
+		})
+
+		It("increments HTTPErrorCount for error responses (400, 404, 500)", func() {
+			labels400 := prometheus.Labels{
+				hostLabel:      host,
+				componentLabel: component,
+				methodLabel:    http.MethodGet,
+				operationLabel: UnknownOperation,
+				codeLabel:      "400",
+			}
+			labels404 := prometheus.Labels{
+				hostLabel:      host,
+				componentLabel: component,
+				methodLabel:    http.MethodGet,
+				operationLabel: UnknownOperation,
+				codeLabel:      "404",
+			}
+			labels500 := prometheus.Labels{
+				hostLabel:      host,
+				componentLabel: component,
+				methodLabel:    http.MethodPost,
+				operationLabel: UnknownOperation,
+				codeLabel:      "500",
+			}
+
+			response1, err := httpClient.Get(server.URL + "/400")
+			Expect(err).NotTo(HaveOccurred())
+			defer response1.Body.Close()
+
+			response2, err := httpClient.Get(server.URL + "/404")
+			Expect(err).NotTo(HaveOccurred())
+			defer response2.Body.Close()
+
+			response3, err := httpClient.Post(server.URL+"/500", "application/json", nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer response3.Body.Close()
+
+			Expect(testutil.ToFloat64(HTTPErrorCount.With(labels400))).To(Equal(float64(1)))
+			Expect(testutil.ToFloat64(HTTPErrorCount.With(labels404))).To(Equal(float64(1)))
+			Expect(testutil.ToFloat64(HTTPErrorCount.With(labels500))).To(Equal(float64(1)))
+		})
+
+		It("does not increment HTTPErrorCount for successful responses", func() {
+			labels := prometheus.Labels{
+				hostLabel:      host,
+				componentLabel: component,
+				methodLabel:    http.MethodGet,
+				operationLabel: UnknownOperation,
+				codeLabel:      "200",
+			}
+
+			response, err := httpClient.Get(server.URL)
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+
+			Expect(testutil.ToFloat64(HTTPErrorCount.With(labels))).To(Equal(float64(0)))
+		})
+	})
+})
+
+func histogramSampleCount(observer prometheus.Observer) uint64 {
+	metric, ok := observer.(prometheus.Metric)
+	Expect(ok).To(BeTrue())
+
+	dtoMetric := &dto.Metric{}
+	Expect(metric.Write(dtoMetric)).To(Succeed())
+
+	return dtoMetric.GetHistogram().GetSampleCount()
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,53 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricPrefix   = "stackit_api"
+	componentLabel = "component"
+	hostLabel      = "host"
+	methodLabel    = "method"
+	operationLabel = "operation"
+	codeLabel      = "status_code"
+)
+
+var (
+	HTTPRequestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricPrefix,
+		Name:      "http_requests_total",
+		Help:      "The number of requests to external APIs",
+	}, []string{componentLabel, hostLabel, methodLabel, operationLabel, codeLabel})
+
+	HTTPErrorCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricPrefix,
+		Name:      "http_errors_total",
+		Help:      "Number of HTTP errors returned by external APIs",
+	}, []string{componentLabel, hostLabel, methodLabel, operationLabel, codeLabel})
+
+	HTTPRequestDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metricPrefix,
+		Name:      "http_request_duration_seconds",
+		Help:      "The response times of external API requests",
+	}, []string{componentLabel, hostLabel, methodLabel, operationLabel, codeLabel})
+)
+
+type Exporter struct {
+}
+
+func NewExporter() *Exporter {
+	return &Exporter{}
+}
+
+func (e *Exporter) Describe(descs chan<- *prometheus.Desc) {
+	HTTPRequestCount.Describe(descs)
+	HTTPErrorCount.Describe(descs)
+	HTTPRequestDurationHistogram.Describe(descs)
+}
+
+func (e *Exporter) Collect(metrics chan<- prometheus.Metric) {
+	HTTPRequestCount.Collect(metrics)
+	HTTPErrorCount.Collect(metrics)
+	HTTPRequestDurationHistogram.Collect(metrics)
+}

--- a/pkg/metrics/suite_test.go
+++ b/pkg/metrics/suite_test.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Provider Suite")
+}


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR adds metrics for API calls. Similar to the metrics in `cloud-provider-stackit` see https://github.com/stackitcloud/cloud-provider-stackit/tree/main/pkg/metrics

**Special notes for your reviewer**:

/hold 
As there is still an open PR for the `cloud-provider-stackit` https://github.com/stackitcloud/cloud-provider-stackit/pull/1516

