### PR TITLE
Disable renovate for k8s.io/ as this is updated based on machine-controller-manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,13 +36,14 @@
       ],
     },
     {
+      description: 'k8s dependencies are updated alongside machine-controller-manager',
+      enabled: false,
+      matchDatasources: [
+        'go'
+      ],
       matchPackageNames: [
         '/^k8s.io/',
       ],
-      matchBaseBranches: [
-        'main',
-      ],
-      automerge: false,
     },
     {
       groupName: 'devTools non-major',


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:

Disable renovate for `k8s.io/` packages in go as this is updated together with the `machine-controller-manager` dependency.

Example #198 show that changes in machine-controller-manager are needed before we can update it.
